### PR TITLE
feat: enhance output formatting with JSON envelope and text formatters

### DIFF
--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -278,7 +278,7 @@ describe("formatSearchResultText", () => {
 
   it("returns no-results message for empty list", () => {
     const result = formatSearchResultText("nonexistent", []);
-    expect(result).toContain('Found 0 events matching "nonexistent"');
+    expect(result).toBe('Found 0 events matching "nonexistent".');
   });
 });
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -19,7 +19,7 @@ function getDateKey(event: CalendarEvent): string {
 }
 
 function getDayOfWeek(dateStr: string): string {
-  const date = new Date(dateStr + "T00:00:00");
+  const date = new Date(dateStr + "T12:00:00Z");
   return DAY_NAMES[date.getDay()] ?? "???";
 }
 
@@ -84,9 +84,9 @@ function formatSearchEventLine(event: CalendarEvent): string {
 export function formatSearchResultText(query: string, events: CalendarEvent[]): string {
   const count = events.length;
   const plural = count === 1 ? "event" : "events";
-  const header = `Found ${count} ${plural} matching "${query}":`;
+  if (count === 0) return `Found 0 events matching "${query}".`;
 
-  if (count === 0) return header;
+  const header = `Found ${count} ${plural} matching "${query}":`;
 
   const lines = [header, ""];
   for (const event of events) {


### PR DESCRIPTION
## Summary
- Add `formatJsonSuccess`/`formatJsonError` with `{ success: true/false, data/error }` envelope
- Add `formatEventListText` with date grouping (`YYYY-MM-DD (Day)` headers), `[All Day]` / `HH:MM-HH:MM` time formats, calendar names, and `[busy]`/`[free]` transparency tags
- Add `formatSearchResultText` with match count header and flat event list
- Add `formatCalendarListText` with `[x]`/`[ ]` enabled/disabled checkboxes and truncated calendar IDs
- Add `formatEventDetailText` for `gcal show` with full event details
- Add `errorCodeToExitCode` mapping (`AUTH_REQUIRED`/`AUTH_EXPIRED` → 2, `INVALID_ARGS` → 3, others → 1)

## Test plan
- [x] 38 unit tests covering all formatters and edge cases
- [x] Tests match exact spec output format for each command
- [x] `bun run test:unit` passes (60 tests)
- [x] `bun run lint` passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)