### PR TITLE
feat: implement timezone resolution module (002-timezone)

### DIFF
--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -73,4 +73,10 @@ describe("parseDateTimeInZone", () => {
     // 2026-01-24T10:00 in America/New_York (EST, -05:00) = 2026-01-24T15:00:00.000Z
     expect(result.toISOString()).toBe("2026-01-24T15:00:00.000Z");
   });
+
+  it("parses datetime with seconds", () => {
+    const result = parseDateTimeInZone("2026-01-24T10:00:00", "Asia/Tokyo");
+    // 2026-01-24T10:00:00 in Asia/Tokyo = 2026-01-24T01:00:00.000Z
+    expect(result.toISOString()).toBe("2026-01-24T01:00:00.000Z");
+  });
 });

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -21,6 +21,7 @@ export function resolveTimezone(cliTz?: string, configTz?: string): string {
 
 const ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ssxxx";
 
+// Expects a pre-validated timezone; callers should use resolveTimezone first.
 export function formatDateTimeInZone(date: Date, timezone: string): string {
   return formatInTimeZone(date, timezone, ISO_FORMAT);
 }
@@ -28,6 +29,7 @@ export function formatDateTimeInZone(date: Date, timezone: string): string {
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const DATETIME_NO_SECONDS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
 
+// Expects a pre-validated timezone; callers should use resolveTimezone first.
 export function parseDateTimeInZone(
   dateStr: string,
   timezone: string,


### PR DESCRIPTION
## Summary

- Implement `resolveTimezone(cliTz?, configTz?)` with priority chain: CLI option > config file > system default
- Implement `formatDateTimeInZone(date, timezone)` for ISO 8601 output with timezone offset (e.g., `2026-01-24T10:00:00+09:00`)
- Implement `parseDateTimeInZone(dateStr, timezone)` supporting date-only (`2026-01-24`) and datetime (`2026-01-24T10:00`) inputs

## Test plan

- [x] `resolveTimezone` returns CLI timezone when provided
- [x] `resolveTimezone` falls back to config timezone when CLI is undefined
- [x] `resolveTimezone` falls back to system timezone when both are undefined
- [x] `resolveTimezone` throws on invalid timezone string
- [x] `formatDateTimeInZone` converts Date to ISO 8601 with offset (positive, negative, UTC)
- [x] `parseDateTimeInZone` handles datetime, date-only, negative offset, and seconds inputs
- [x] All 38 unit tests pass
- [x] `bun run lint` passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)