### PR TITLE
feat: add auth command (007)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "date-fns": "^3.0.0",
     "date-fns-tz": "^3.0.0",
     "googleapis": "^130.0.0",
-    "smol-toml": "^1.0.0"
+    "smol-toml": "^1.0.0",
+    "zod": "^4.0.0-beta"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- Add `src/commands/auth.ts` with `handleAuth`, `handleAuthStatus`, `handleAuthLogout`, and `createAuthCommand` exports
- Default `gcal auth` starts OAuth flow when unauthenticated, shows status when already authenticated
- `--status` flag shows email and token expiry in text or JSON format (respects `-f` flag)
- `--logout` flag revokes tokens and removes credentials file
- Appropriate exit codes: 0 on success, 2 on auth errors
- 12 unit tests covering all handlers and edge cases

## Test plan
- [x] `bun run test:all` passes (152 tests)
- [x] `bun run lint` passes (0 warnings, 0 errors)
- [x] `bun run format:check` passes
- [ ] Command registration in main CLI is deferred to task 008

🤖 Generated with [Claude Code](https://claude.com/claude-code)