### PR TITLE
feat: Google Calendar API wrapper — write operations (009b)

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -784,6 +784,28 @@ describe("updateEvent", () => {
     expect(result.all_day).toBe(true);
   });
 
+  it("throws when partial time fields are provided (start without end/allDay)", async () => {
+    const api = createMockApi({});
+
+    const input = { start: "2024-03-15T09:00:00Z" } as UpdateEventInput;
+
+    await expect(updateEvent(api, "cal1", "Cal", "evt1", input)).rejects.toThrow(
+      "start, end, and allDay must all be provided together",
+    );
+    expect(api.events.patch).not.toHaveBeenCalled();
+  });
+
+  it("throws when start and end provided without allDay", async () => {
+    const api = createMockApi({});
+
+    const input = { start: "2024-03-15T09:00:00Z", end: "2024-03-15T10:00:00Z" } as UpdateEventInput;
+
+    await expect(updateEvent(api, "cal1", "Cal", "evt1", input)).rejects.toThrow(
+      "start, end, and allDay must all be provided together",
+    );
+    expect(api.events.patch).not.toHaveBeenCalled();
+  });
+
   it("maps API errors correctly", async () => {
     const patchFn = vi
       .fn()


### PR DESCRIPTION
## Summary
- Add `createEvent` supporting timed and all-day events with transparency control
- Add `updateEvent` for partial updates (only changed fields sent via PATCH)
- Add `deleteEvent` with success and NOT_FOUND error handling
- Extend `GoogleCalendarApi` interface with `insert`, `patch`, `delete` methods
- All write operations return normalized internal types and map API errors to appropriate error codes

## Test plan
- [x] `createEvent` sends correct payload for timed event and returns normalized event
- [x] `createEvent` handles all-day event creation (date vs dateTime)
- [x] `createEvent` sets transparency (opaque/transparent)
- [x] `createEvent` maps API errors correctly
- [x] `updateEvent` sends partial update and returns normalized updated event
- [x] `updateEvent` handles time field updates with timezone
- [x] `updateEvent` handles updating to all-day event
- [x] `updateEvent` maps API errors correctly
- [x] `deleteEvent` sends delete request and returns success
- [x] `deleteEvent` throws NOT_FOUND for non-existent event
- [x] `deleteEvent` maps API errors correctly
- [x] `bun run test:all` — 214 tests pass
- [x] `bun run lint` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)