### PR TITLE
feat: add task list settings to gcal init

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -518,6 +518,7 @@ export function registerCommands(program: Command): void {
         format: globalOpts.format,
         quiet: globalOpts.quiet,
         write,
+        writeErr: (msg) => process.stderr.write(msg + "\n"),
         force: initOpts.force ?? false,
         all: initOpts.all ?? false,
         local: initOpts.local ?? false,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -31,6 +31,7 @@ import {
 } from "../lib/auth.ts";
 import { createReadlinePrompt } from "../lib/prompt.ts";
 import { listCalendars, listEvents, createEvent, getEvent } from "../lib/api.ts";
+import { listTaskLists } from "../lib/tasks-api.ts";
 import type { GoogleCalendarApi } from "../lib/api.ts";
 import { resolveTimezone } from "../lib/timezone.ts";
 import { resolveEventCalendar } from "../lib/resolve-calendar.ts";
@@ -484,6 +485,13 @@ export function registerCommands(program: Command): void {
         listCalendars: async () => {
           const api = await getApi();
           return listCalendars(api);
+        },
+        listTaskLists: async () => {
+          const oauth2Client = await getAuthenticatedClient(fsAdapter);
+          const tasksClient = createGoogleTasksClient(
+            google.tasks({ version: "v1", auth: oauth2Client }),
+          );
+          return listTaskLists(tasksClient);
         },
         requestAuth: async () => {
           apiRef = null;

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import type { Calendar } from "../types/index.ts";
+import type { Calendar, TaskList } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import { ApiError } from "../lib/api.ts";
 import { parseConfig } from "../lib/config.ts";
@@ -321,5 +321,132 @@ describe("handleInit", () => {
     expect(result.exitCode).toBe(ExitCode.SUCCESS);
     expect(requestAuth).toHaveBeenCalled();
     expect(listCalendars).toHaveBeenCalledTimes(2);
+  });
+
+  describe("task lists", () => {
+    function makeTaskList(overrides: Partial<TaskList> = {}): TaskList {
+      return {
+        id: "@default",
+        title: "My Tasks",
+        updated: "2026-01-01T00:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("includes task_lists in generated config when listTaskLists provided", async () => {
+      const fs = makeFs();
+      const opts = makeOpts({
+        fs,
+        listTaskLists: vi.fn().mockResolvedValue([
+          makeTaskList({ id: "@default", title: "My Tasks" }),
+          makeTaskList({ id: "abc123", title: "Work" }),
+        ]),
+      });
+
+      await handleInit(opts);
+
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const parsed = parseConfig(writtenToml);
+      expect(parsed.task_lists).toHaveLength(2);
+    });
+
+    it("enables only default task list by default", async () => {
+      const fs = makeFs();
+      const opts = makeOpts({
+        fs,
+        listTaskLists: vi.fn().mockResolvedValue([
+          makeTaskList({ id: "@default", title: "My Tasks" }),
+          makeTaskList({ id: "abc123", title: "Work" }),
+        ]),
+      });
+
+      await handleInit(opts);
+
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const parsed = parseConfig(writtenToml);
+      const defaultList = parsed.task_lists.find((t) => t.id === "@default");
+      const workList = parsed.task_lists.find((t) => t.id === "abc123");
+      expect(defaultList?.enabled).toBe(true);
+      expect(workList?.enabled).toBe(false);
+    });
+
+    it("--all enables all task lists", async () => {
+      const fs = makeFs();
+      const opts = makeOpts({
+        fs,
+        all: true,
+        listTaskLists: vi.fn().mockResolvedValue([
+          makeTaskList({ id: "@default", title: "My Tasks" }),
+          makeTaskList({ id: "abc123", title: "Work" }),
+        ]),
+      });
+
+      await handleInit(opts);
+
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const parsed = parseConfig(writtenToml);
+      expect(parsed.task_lists.every((t) => t.enabled)).toBe(true);
+    });
+
+    it("shows enabled task lists in text output", async () => {
+      const output: string[] = [];
+      const opts = makeOpts({
+        write: (msg) => output.push(msg),
+        listTaskLists: vi.fn().mockResolvedValue([
+          makeTaskList({ id: "@default", title: "My Tasks" }),
+          makeTaskList({ id: "abc123", title: "Work" }),
+        ]),
+      });
+
+      await handleInit(opts);
+
+      const text = output.join("\n");
+      expect(text).toContain("Enabled task lists:");
+      expect(text).toContain("My Tasks (@default)");
+      expect(text).not.toContain("Work (abc123)");
+    });
+
+    it("includes task_lists in JSON output", async () => {
+      const output: string[] = [];
+      const opts = makeOpts({
+        format: "json",
+        write: (msg) => output.push(msg),
+        listTaskLists: vi.fn().mockResolvedValue([
+          makeTaskList({ id: "@default", title: "My Tasks" }),
+        ]),
+      });
+
+      await handleInit(opts);
+
+      const json = JSON.parse(output[0]!);
+      expect(json.data.task_lists).toBeInstanceOf(Array);
+      expect(json.data.task_lists).toHaveLength(1);
+    });
+
+    it("skips task lists when listTaskLists is not provided", async () => {
+      const fs = makeFs();
+      const opts = makeOpts({ fs });
+
+      await handleInit(opts);
+
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      expect(writtenToml).not.toContain("task_lists");
+    });
+
+    it("skips task lists when listTaskLists throws an error", async () => {
+      const fs = makeFs();
+      const output: string[] = [];
+      const opts = makeOpts({
+        fs,
+        write: (msg) => output.push(msg),
+        listTaskLists: vi.fn().mockRejectedValue(new Error("Tasks API not available")),
+      });
+
+      const result = await handleInit(opts);
+
+      expect(result.exitCode).toBe(ExitCode.SUCCESS);
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      expect(writtenToml).not.toContain("task_lists");
+    });
   });
 });

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -448,9 +448,11 @@ describe("handleInit", () => {
     it("skips task lists when listTaskLists throws an error", async () => {
       const fs = makeFs();
       const output: string[] = [];
+      const errOutput: string[] = [];
       const opts = makeOpts({
         fs,
         write: (msg) => output.push(msg),
+        writeErr: (msg) => errOutput.push(msg),
         listTaskLists: vi.fn().mockRejectedValue(new Error("Tasks API not available")),
       });
 
@@ -460,6 +462,7 @@ describe("handleInit", () => {
       const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
         .calls[0]![1] as string;
       expect(writtenToml).not.toContain("task_lists");
+      expect(errOutput.join("\n")).toContain("[init] Tasks API unavailable, skipping task lists");
     });
   });
 });

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -337,15 +337,18 @@ describe("handleInit", () => {
       const fs = makeFs();
       const opts = makeOpts({
         fs,
-        listTaskLists: vi.fn().mockResolvedValue([
-          makeTaskList({ id: "@default", title: "My Tasks" }),
-          makeTaskList({ id: "abc123", title: "Work" }),
-        ]),
+        listTaskLists: vi
+          .fn()
+          .mockResolvedValue([
+            makeTaskList({ id: "@default", title: "My Tasks" }),
+            makeTaskList({ id: "abc123", title: "Work" }),
+          ]),
       });
 
       await handleInit(opts);
 
-      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
+        .calls[0]![1] as string;
       const parsed = parseConfig(writtenToml);
       expect(parsed.task_lists).toHaveLength(2);
     });
@@ -354,15 +357,18 @@ describe("handleInit", () => {
       const fs = makeFs();
       const opts = makeOpts({
         fs,
-        listTaskLists: vi.fn().mockResolvedValue([
-          makeTaskList({ id: "@default", title: "My Tasks" }),
-          makeTaskList({ id: "abc123", title: "Work" }),
-        ]),
+        listTaskLists: vi
+          .fn()
+          .mockResolvedValue([
+            makeTaskList({ id: "@default", title: "My Tasks" }),
+            makeTaskList({ id: "abc123", title: "Work" }),
+          ]),
       });
 
       await handleInit(opts);
 
-      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
+        .calls[0]![1] as string;
       const parsed = parseConfig(writtenToml);
       const defaultList = parsed.task_lists.find((t) => t.id === "@default");
       const workList = parsed.task_lists.find((t) => t.id === "abc123");
@@ -375,15 +381,18 @@ describe("handleInit", () => {
       const opts = makeOpts({
         fs,
         all: true,
-        listTaskLists: vi.fn().mockResolvedValue([
-          makeTaskList({ id: "@default", title: "My Tasks" }),
-          makeTaskList({ id: "abc123", title: "Work" }),
-        ]),
+        listTaskLists: vi
+          .fn()
+          .mockResolvedValue([
+            makeTaskList({ id: "@default", title: "My Tasks" }),
+            makeTaskList({ id: "abc123", title: "Work" }),
+          ]),
       });
 
       await handleInit(opts);
 
-      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
+        .calls[0]![1] as string;
       const parsed = parseConfig(writtenToml);
       expect(parsed.task_lists.every((t) => t.enabled)).toBe(true);
     });
@@ -392,10 +401,12 @@ describe("handleInit", () => {
       const output: string[] = [];
       const opts = makeOpts({
         write: (msg) => output.push(msg),
-        listTaskLists: vi.fn().mockResolvedValue([
-          makeTaskList({ id: "@default", title: "My Tasks" }),
-          makeTaskList({ id: "abc123", title: "Work" }),
-        ]),
+        listTaskLists: vi
+          .fn()
+          .mockResolvedValue([
+            makeTaskList({ id: "@default", title: "My Tasks" }),
+            makeTaskList({ id: "abc123", title: "Work" }),
+          ]),
       });
 
       await handleInit(opts);
@@ -411,9 +422,9 @@ describe("handleInit", () => {
       const opts = makeOpts({
         format: "json",
         write: (msg) => output.push(msg),
-        listTaskLists: vi.fn().mockResolvedValue([
-          makeTaskList({ id: "@default", title: "My Tasks" }),
-        ]),
+        listTaskLists: vi
+          .fn()
+          .mockResolvedValue([makeTaskList({ id: "@default", title: "My Tasks" })]),
       });
 
       await handleInit(opts);
@@ -429,7 +440,8 @@ describe("handleInit", () => {
 
       await handleInit(opts);
 
-      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
+        .calls[0]![1] as string;
       expect(writtenToml).not.toContain("task_lists");
     });
 
@@ -445,7 +457,8 @@ describe("handleInit", () => {
       const result = await handleInit(opts);
 
       expect(result.exitCode).toBe(ExitCode.SUCCESS);
-      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string;
+      const writtenToml = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock
+        .calls[0]![1] as string;
       expect(writtenToml).not.toContain("task_lists");
     });
   });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { Command } from "commander";
-import type { Calendar, CommandResult, OutputFormat, TaskList, TaskListConfig } from "../types/index.ts";
+import type {
+  Calendar,
+  CommandResult,
+  OutputFormat,
+  TaskList,
+  TaskListConfig,
+} from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import { generateConfigToml, getDefaultConfigPath } from "../lib/config.ts";
 import { isAuthRequiredError } from "../lib/api.ts";
@@ -105,7 +111,11 @@ export async function handleInit(opts: HandleInitOptions): Promise<CommandResult
   const timezone = resolveTimezone(opts.timezone);
 
   // Generate TOML and write
-  const toml = generateConfigToml(configCalendars, timezone, configTaskLists.length > 0 ? configTaskLists : undefined);
+  const toml = generateConfigToml(
+    configCalendars,
+    timezone,
+    configTaskLists.length > 0 ? configTaskLists : undefined,
+  );
   const dir = path.dirname(configPath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(configPath, toml);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -26,6 +26,7 @@ export interface HandleInitOptions {
   format: OutputFormat;
   quiet: boolean;
   write: (msg: string) => void;
+  writeErr?: (msg: string) => void;
   force: boolean;
   all: boolean;
   local: boolean;
@@ -38,6 +39,7 @@ function resolveTimezone(cliTimezone?: string): string {
 
 export async function handleInit(opts: HandleInitOptions): Promise<CommandResult> {
   const { fs, format, quiet, write, force, all, local, requestAuth } = opts;
+  const writeErr = quiet ? () => {} : (opts.writeErr ?? (() => {}));
 
   // Determine output path
   const configPath = local ? `${process.cwd()}/gcal-cli.toml` : getDefaultConfigPath();
@@ -103,7 +105,7 @@ export async function handleInit(opts: HandleInitOptions): Promise<CommandResult
         enabled: all || tl.id === "@default",
       }));
     } catch {
-      // Tasks API not available - skip task lists
+      writeErr("[init] Tasks API unavailable, skipping task lists");
     }
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { Command } from "commander";
-import type { Calendar, CommandResult, OutputFormat } from "../types/index.ts";
+import type { Calendar, CommandResult, OutputFormat, TaskList, TaskListConfig } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import { generateConfigToml, getDefaultConfigPath } from "../lib/config.ts";
 import { isAuthRequiredError } from "../lib/api.ts";
@@ -14,6 +14,7 @@ export interface InitFsAdapter {
 
 export interface HandleInitOptions {
   listCalendars: () => Promise<Calendar[]>;
+  listTaskLists?: () => Promise<TaskList[]>;
   requestAuth?: () => Promise<void>;
   fs: InitFsAdapter;
   format: OutputFormat;
@@ -85,17 +86,33 @@ export async function handleInit(opts: HandleInitOptions): Promise<CommandResult
     enabled: all || cal.primary,
   }));
 
+  // Fetch task lists (skip on error - Tasks API scope may not be available)
+  let configTaskLists: TaskListConfig[] = [];
+  if (opts.listTaskLists) {
+    try {
+      const taskLists = await opts.listTaskLists();
+      configTaskLists = taskLists.map((tl) => ({
+        id: tl.id,
+        name: tl.title,
+        enabled: all || tl.id === "@default",
+      }));
+    } catch {
+      // Tasks API not available - skip task lists
+    }
+  }
+
   // Resolve timezone
   const timezone = resolveTimezone(opts.timezone);
 
   // Generate TOML and write
-  const toml = generateConfigToml(configCalendars, timezone);
+  const toml = generateConfigToml(configCalendars, timezone, configTaskLists.length > 0 ? configTaskLists : undefined);
   const dir = path.dirname(configPath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(configPath, toml);
 
   // Output results
   const enabledCalendars = configCalendars.filter((c) => c.enabled);
+  const enabledTaskLists = configTaskLists.filter((t) => t.enabled);
 
   if (quiet) {
     write(configPath);
@@ -103,25 +120,38 @@ export async function handleInit(opts: HandleInitOptions): Promise<CommandResult
   }
 
   if (format === "json") {
-    write(
-      formatJsonSuccess({
-        path: configPath,
-        timezone,
-        calendars: configCalendars.map((c) => ({
-          id: c.id,
-          name: c.name,
-          enabled: c.enabled,
-        })),
-        enabled_count: enabledCalendars.length,
-        total_count: configCalendars.length,
-      }),
-    );
+    const data: Record<string, unknown> = {
+      path: configPath,
+      timezone,
+      calendars: configCalendars.map((c) => ({
+        id: c.id,
+        name: c.name,
+        enabled: c.enabled,
+      })),
+      enabled_count: enabledCalendars.length,
+      total_count: configCalendars.length,
+    };
+    if (configTaskLists.length > 0) {
+      data.task_lists = configTaskLists.map((t) => ({
+        id: t.id,
+        name: t.name,
+        enabled: t.enabled,
+      }));
+    }
+    write(formatJsonSuccess(data));
   } else {
     write(`Config file created: ${configPath}`);
     write("");
     write("Enabled calendars:");
     for (const cal of enabledCalendars) {
       write(`  - ${cal.name} (${cal.id})`);
+    }
+    if (enabledTaskLists.length > 0) {
+      write("");
+      write("Enabled task lists:");
+      for (const tl of enabledTaskLists) {
+        write(`  - ${tl.name} (${tl.id})`);
+      }
     }
     write("");
     write(`Timezone: ${timezone}`);

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -8,7 +8,7 @@ import {
   generateConfigToml,
   getDefaultConfigPath,
 } from "./config.ts";
-import type { AppConfig, CalendarConfig } from "../types/index.ts";
+import type { AppConfig, CalendarConfig, TaskListConfig } from "../types/index.ts";
 
 describe("findConfigPath", () => {
   beforeEach(() => {
@@ -369,5 +369,50 @@ describe("generateConfigToml", () => {
     const parsed = parseConfig(toml);
     expect(parsed.calendars).toEqual([]);
     expect(parsed.timezone).toBe("UTC");
+  });
+
+  it("generates TOML with task_lists section", () => {
+    const calendars: CalendarConfig[] = [
+      { id: "primary", name: "Main Calendar", enabled: true },
+    ];
+    const taskLists: TaskListConfig[] = [
+      { id: "@default", name: "My Tasks", enabled: true },
+      { id: "abc123", name: "Work", enabled: false },
+    ];
+    const toml = generateConfigToml(calendars, "Asia/Tokyo", taskLists);
+    expect(toml).toContain("[[task_lists]]");
+    expect(toml).toContain('id = "@default"');
+    expect(toml).toContain('name = "My Tasks"');
+    expect(toml).toContain('id = "abc123"');
+    expect(toml).toContain('name = "Work"');
+  });
+
+  it("round-trips task_lists through parseConfig", () => {
+    const calendars: CalendarConfig[] = [
+      { id: "primary", name: "Main Calendar", enabled: true },
+    ];
+    const taskLists: TaskListConfig[] = [
+      { id: "@default", name: "My Tasks", enabled: true },
+      { id: "abc123", name: "Work", enabled: false },
+    ];
+    const toml = generateConfigToml(calendars, "Asia/Tokyo", taskLists);
+    const parsed = parseConfig(toml);
+    expect(parsed.task_lists).toEqual(taskLists);
+  });
+
+  it("omits task_lists section when not provided", () => {
+    const calendars: CalendarConfig[] = [
+      { id: "primary", name: "Main Calendar", enabled: true },
+    ];
+    const toml = generateConfigToml(calendars, "Asia/Tokyo");
+    expect(toml).not.toContain("task_lists");
+  });
+
+  it("omits task_lists section when empty array", () => {
+    const calendars: CalendarConfig[] = [
+      { id: "primary", name: "Main Calendar", enabled: true },
+    ];
+    const toml = generateConfigToml(calendars, "Asia/Tokyo", []);
+    expect(toml).not.toContain("task_lists");
   });
 });

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -372,9 +372,7 @@ describe("generateConfigToml", () => {
   });
 
   it("generates TOML with task_lists section", () => {
-    const calendars: CalendarConfig[] = [
-      { id: "primary", name: "Main Calendar", enabled: true },
-    ];
+    const calendars: CalendarConfig[] = [{ id: "primary", name: "Main Calendar", enabled: true }];
     const taskLists: TaskListConfig[] = [
       { id: "@default", name: "My Tasks", enabled: true },
       { id: "abc123", name: "Work", enabled: false },
@@ -388,9 +386,7 @@ describe("generateConfigToml", () => {
   });
 
   it("round-trips task_lists through parseConfig", () => {
-    const calendars: CalendarConfig[] = [
-      { id: "primary", name: "Main Calendar", enabled: true },
-    ];
+    const calendars: CalendarConfig[] = [{ id: "primary", name: "Main Calendar", enabled: true }];
     const taskLists: TaskListConfig[] = [
       { id: "@default", name: "My Tasks", enabled: true },
       { id: "abc123", name: "Work", enabled: false },
@@ -401,17 +397,13 @@ describe("generateConfigToml", () => {
   });
 
   it("omits task_lists section when not provided", () => {
-    const calendars: CalendarConfig[] = [
-      { id: "primary", name: "Main Calendar", enabled: true },
-    ];
+    const calendars: CalendarConfig[] = [{ id: "primary", name: "Main Calendar", enabled: true }];
     const toml = generateConfigToml(calendars, "Asia/Tokyo");
     expect(toml).not.toContain("task_lists");
   });
 
   it("omits task_lists section when empty array", () => {
-    const calendars: CalendarConfig[] = [
-      { id: "primary", name: "Main Calendar", enabled: true },
-    ];
+    const calendars: CalendarConfig[] = [{ id: "primary", name: "Main Calendar", enabled: true }];
     const toml = generateConfigToml(calendars, "Asia/Tokyo", []);
     expect(toml).not.toContain("task_lists");
   });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -108,7 +108,11 @@ function escapeTomlString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-export function generateConfigToml(calendars: CalendarConfig[], timezone?: string): string {
+export function generateConfigToml(
+  calendars: CalendarConfig[],
+  timezone?: string,
+  taskLists?: TaskListConfig[],
+): string {
   const lines: string[] = [];
 
   if (timezone) {
@@ -122,6 +126,16 @@ export function generateConfigToml(calendars: CalendarConfig[], timezone?: strin
     lines.push(`name = "${escapeTomlString(cal.name)}"`);
     lines.push(`enabled = ${String(cal.enabled)}`);
     lines.push("");
+  }
+
+  if (taskLists && taskLists.length > 0) {
+    for (const tl of taskLists) {
+      lines.push("[[task_lists]]");
+      lines.push(`id = "${escapeTomlString(tl.id)}"`);
+      lines.push(`name = "${escapeTomlString(tl.name)}"`);
+      lines.push(`enabled = ${String(tl.enabled)}`);
+      lines.push("");
+    }
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- `gcal init` now fetches task lists from Google Tasks API and includes `[[task_lists]]` sections in generated `config.toml`
- Default task list (`@default`) is enabled by default; `--all` flag enables all task lists
- Gracefully skips task lists when Tasks API scope is unavailable (no error)

## Changes
- `src/lib/config.ts`: Extended `generateConfigToml()` to accept optional `TaskListConfig[]`
- `src/commands/init.ts`: Added `listTaskLists` to `HandleInitOptions`, fetch with error fallback, include in text/JSON output
- `src/commands/index.ts`: Wired up Google Tasks client for init command

## Test plan
- [x] Unit tests for `generateConfigToml` with task lists (round-trip, omit when empty)
- [x] Unit tests for `handleInit` task list integration (default enabled, --all, text output, JSON output, skip on error, skip when not provided)
- [x] All 638 unit tests pass
- [x] Lint clean
- [x] Format clean

Closes #038

🤖 Generated with [Claude Code](https://claude.com/claude-code)