### PR TITLE
fix: show multi-day events under every day they occupy (#53)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "vitest",
     "test:unit": "vitest run src",
     "test:integration": "vitest run tests/integration",
-    "test:e2e": "vitest run tests/e2e",
+    "test:e2e": "bun run --bun vitest run tests/e2e",
     "test:all": "vitest run",
     "lint": "oxlint src tests",
     "format": "oxfmt src tests",

--- a/spec/output.md
+++ b/spec/output.md
@@ -16,6 +16,34 @@ Human-readable format for terminal use.
   [All Day]     Vacation (Main Calendar)
 ```
 
+#### Multi-day Events
+
+An event is listed under **every day it occupies**, not just its start date.
+All-day events spanning multiple days carry a `n/m` day counter; single-day
+all-day events keep the plain `[All Day]` label.
+
+```
+2026-12-05 (Sat)
+  [All Day 1/2]   Aコース (Main Calendar)
+  10:00-11:00     Team Meeting (Main Calendar) [busy]
+
+2026-12-06 (Sun)
+  [All Day 2/2]   Aコース (Main Calendar)
+```
+
+Notes:
+
+- The Google Calendar API reports the all-day `end` as **exclusive**:
+  `2026-12-05`–`2026-12-07` is a two-day event (12/05 and 12/06).
+- The day counter reflects the event's full span even when the requested range
+  shows only part of it (`gcal list --from 2026-12-06 --to 2026-12-06` prints
+  `[All Day 2/2]`). Days outside the requested range are not rendered.
+- Timed events crossing midnight are shown on each day with that day's occupied
+  range (`23:00-24:00`, then `00:00-01:00`). An event ending exactly at `00:00`
+  does not appear on the following day.
+- The time column widens to fit the longest label in the output, so a listing
+  without multi-day events keeps the 11-character `HH:MM-HH:MM` width.
+
 ### `gcal search` Text Output
 
 ```
@@ -24,6 +52,16 @@ Found 3 events matching "meeting":
 2026-01-24 10:00-11:00  Team Meeting (Main Calendar) [busy]
 2026-01-28 09:00-10:00  Project Meeting (Main Calendar) [busy]
 2026-02-01 14:00-15:00  Review Meeting (Work Calendar) [busy]
+```
+
+Search lists one row per event rather than per day, so a multi-day span is
+annotated inline:
+
+```
+Found 2 events matching "A":
+
+2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar)
+2026-12-05 23:00-12/06 01:00      Night Shift (Main Calendar) [busy]
 ```
 
 ### `gcal calendars` Text Output
@@ -50,7 +88,19 @@ Minimal output for scripting and piping. JSON mode (`-f json`) is unaffected by 
 | calendars | Calendar ID per line | `primary` |
 | init | Config file path only | `~/.config/gcal-cli/config.toml` |
 
+`gcal list --quiet` expands multi-day events to one line per occupied day, in
+the same way as the text output:
+
+```
+12/05 All day      Aコース
+12/06 All day      Aコース
+12/06 09:00-10:00  Team Meeting
+```
+
 ### `gcal search` Quiet Output
+
+Search is event-oriented, so each match stays on a single line even when it
+spans several days.
 
 ```
 01/24 10:00-11:00  Team Meeting

--- a/spec/tasks/039-multi-day-event-display.md
+++ b/spec/tasks/039-multi-day-event-display.md
@@ -78,21 +78,24 @@ export function expandEventsByDay(events: CalendarEvent[], range?: DayRange): Ev
 
 ## Implementation Steps
 
-- [ ] `src/lib/event-days.test.ts`: `expandEventsByDay()` の失敗テストを書く（終日単日 / 終日複数日 / clip / 日またぎ時刻 / 終了 00:00 / 3日以上）
-- [ ] `src/lib/event-days.ts`: `expandEventsByDay()` を実装
-- [ ] `src/lib/output.test.ts`: `formatEventListText()` の複数日展開・`[All Day n/m]`・動的列幅の失敗テストを追加
-- [ ] `src/lib/output.ts`: `formatEventListText(events, range?)` を `expandEventsByDay()` ベースに書き換え、グループキーを日付昇順で明示的にソート
-- [ ] `src/lib/output.ts`: `formatTimeRange()` を `EventDay` 対応にし、`[All Day n/m]` を出力
-- [ ] `src/lib/output.test.ts` / `src/lib/output.ts`: `formatQuietText(events, range?)` の日別展開を追加
-- [ ] `src/lib/output.test.ts` / `src/lib/output.ts`: `formatSearchEventLine()` の終日ラベルに期間を併記
-- [ ] `src/commands/list.ts`: `dateRange` から `DayRange` を導出して `formatEventListText` / `formatQuietText` に渡す
-- [ ] `src/commands/list.test.ts`: 2日目単独指定で複数日イベントが表示されることを確認するテストを追加
-- [ ] `spec/output.md`: 複数日イベントの表示例と列幅の説明を追加
-- [ ] `bun run test` pass
-- [ ] `bun run lint` pass
-- [ ] `bun run format:check` pass
+- [x] `src/lib/event-days.test.ts`: `expandEventsByDay()` の失敗テストを書く（終日単日 / 終日複数日 / clip / 日またぎ時刻 / 終了 00:00 / 3日以上）
+- [x] `src/lib/event-days.ts`: `expandEventsByDay()` を実装
+- [x] `src/lib/output.test.ts`: `formatEventListText()` の複数日展開・`[All Day n/m]`・動的列幅の失敗テストを追加
+- [x] `src/lib/output.ts`: `formatEventListText(events, range?)` を `expandEventsByDay()` ベースに書き換え、グループキーを日付昇順で明示的にソート（ソートは `expandEventsByDay()` 側に集約）
+- [x] `src/lib/output.ts`: `formatTimeRange()` を `EventDay` 対応にし、`[All Day n/m]` を出力
+- [x] `src/lib/output.test.ts` / `src/lib/output.ts`: `formatQuietText(events, range?)` の日別展開を追加
+- [x] `src/lib/output.test.ts` / `src/lib/output.ts`: search 行の終日ラベルに期間を併記（`formatEventSpanLabel()`）
+- [x] `src/commands/list.ts`: `dateRange` から `DayRange` を導出して `formatEventListText` / `formatQuietText` に渡す（`toDayRange()`）
+- [x] `src/commands/list.test.ts`: 2日目単独指定で複数日イベントが表示されることを確認するテストを追加
+- [x] `spec/output.md`: 複数日イベントの表示例と列幅の説明を追加
+- [x] `bun run test` pass (unit 677 / integration 72)
+- [x] `bun run lint` pass
+- [x] `bun run format:check` pass
+- [x] `bun run typecheck` pass
 
 ## E2E Test
+
+認証が必要なため未実行。マージ前に手動で確認する。
 
 - [ ] 複数日の終日イベントを作成し、`gcal list --from <2日目> --to <2日目>` でそのイベントが表示されること
 - [ ] `gcal list --from <初日> --to <最終日>` で全ての日付グループに `[All Day n/m]` 付きで表示されること
@@ -100,16 +103,16 @@ export function expandEventsByDay(events: CalendarEvent[], range?: DayRange): Ev
 
 ## Acceptance Criteria
 
-- [ ] 複数日にまたがる終日イベントが、占有する全ての日付グループに表示される
-- [ ] 終日ラベルに `[All Day 1/2]` の形式で日目が併記される（単日イベントは `[All Day]` のまま）
-- [ ] 終日イベントの `end` exclusive が正しく扱われる（`12-05`〜`12-07` は2日間）
-- [ ] 表示範囲外の日付グループが生成されない
-- [ ] 日をまたぐ時刻指定イベントが両日に、各日の実占有時間帯で表示される
-- [ ] 終了が丁度 00:00 の時刻指定イベントで翌日のグループが生成されない
-- [ ] `--quiet` 出力でも複数日イベントが全ての日に表示される
-- [ ] `search` の終日イベント行に期間が併記される
-- [ ] JSON 出力は変更されない
-- [ ] 既存テストが pass する
+- [x] 複数日にまたがる終日イベントが、占有する全ての日付グループに表示される
+- [x] 終日ラベルに `[All Day 1/2]` の形式で日目が併記される（単日イベントは `[All Day]` のまま）
+- [x] 終日イベントの `end` exclusive が正しく扱われる（`12-05`〜`12-07` は2日間）
+- [x] 表示範囲外の日付グループが生成されない
+- [x] 日をまたぐ時刻指定イベントが両日に、各日の実占有時間帯で表示される
+- [x] 終了が丁度 00:00 の時刻指定イベントで翌日のグループが生成されない
+- [x] `--quiet` 出力でも複数日イベントが全ての日に表示される
+- [x] `search` の終日イベント行に期間が併記される
+- [x] JSON 出力は変更されない
+- [x] 既存テストが pass する
 
 ## Out of Scope
 

--- a/spec/tasks/039-multi-day-event-display.md
+++ b/spec/tasks/039-multi-day-event-display.md
@@ -95,11 +95,16 @@ export function expandEventsByDay(events: CalendarEvent[], range?: DayRange): Ev
 
 ## E2E Test
 
-認証が必要なため未実行。マージ前に手動で確認する。
+`tests/e2e/multi-day-events.test.ts` として実装（実行結果: 31/31 pass）。
 
-- [ ] 複数日の終日イベントを作成し、`gcal list --from <2日目> --to <2日目>` でそのイベントが表示されること
-- [ ] `gcal list --from <初日> --to <最終日>` で全ての日付グループに `[All Day n/m]` 付きで表示されること
-- [ ] `gcal list -f json` の出力が変わっていないこと
+`test:e2e` スクリプトは `Bun.spawn` を使う `tests/e2e/helpers.ts` を Node 上の vitest で実行していたため
+`ReferenceError: Bun is not defined` で全滅していた（本タスク以前からの不具合）。`bun run --bun vitest` に修正。
+
+- [x] 複数日の終日イベントを作成し、`gcal list --from <2日目> --to <2日目>` でそのイベントが表示されること
+- [x] `gcal list --from <初日> --to <最終日>` で全ての日付グループに `[All Day n/m]` 付きで表示されること
+- [x] `gcal list --quiet` で占有日ごとに1行出力されること
+- [x] `gcal list -f json` の出力が変わっていないこと（1件のみ・元の start/end を保持）
+- [x] 日をまたぐ時刻指定イベントが両日に各日の実占有時間帯で表示されること
 
 ## Acceptance Criteria
 

--- a/spec/tasks/039-multi-day-event-display.md
+++ b/spec/tasks/039-multi-day-event-display.md
@@ -1,0 +1,116 @@
+# Task: 複数日にまたがるイベントを全ての日付グループに表示
+
+## Purpose
+
+複数日にまたがるイベントが `gcal list` のテキスト出力で**開始日のグループにしか表示されない**問題を修正する (#53)。
+
+2日目以降の日付だけを `--from` / `--to` で指定しても何も出力されず、その日が空いているように見えるため、空き日程調査で誤判定が起きる。`-f json` は正しくイベントを返すので、テキスト整形層のみの問題。
+
+## Context
+
+- Issue: #53
+- Related files:
+  - `src/lib/output.ts` — `getDateKey()` (14-19行), `formatEventListText()` (39-71行), `formatTimeRange()` (26-33行), `formatQuietText()` (97-113行), `formatSearchEventLine()` (73-81行)
+  - `src/lib/date-utils.ts` — `addDaysToDateString()` を再利用
+  - `src/commands/list.ts` — `handleList()` から表示範囲を渡す (167-175行)
+  - `src/commands/search.ts` — `formatQuietText` / `formatSearchResultText` の呼び出し元 (104-106行)
+- Related specs: `spec/output.md`
+- Dependencies: なし
+
+## Root Cause
+
+`getDateKey()` がイベントの `start` だけを返し、その値でグループ化しているため、イベントが占有する期間 (`start` 〜 `end`) が考慮されていない。
+
+## Design Decisions
+
+### 展開ロジックの分離
+
+新モジュール `src/lib/event-days.ts` に純粋関数として切り出し、単体テストしやすくする。
+
+```ts
+export interface DayRange {
+  from: string; // YYYY-MM-DD (inclusive)
+  to: string;   // YYYY-MM-DD (inclusive)
+}
+
+export interface EventDay {
+  date: string;        // YYYY-MM-DD
+  event: CalendarEvent;
+  dayIndex: number;    // 1-based
+  dayCount: number;    // イベント全体の占有日数
+  startTime: string;   // "HH:MM" — その日の占有開始 (all_day は "")
+  endTime: string;     // "HH:MM" — その日の占有終了 (all_day は "")
+}
+
+export function expandEventsByDay(events: CalendarEvent[], range?: DayRange): EventDay[];
+```
+
+- `range` を渡すとその範囲外の日付を切り捨てる (clip)。省略時は全期間を展開。
+- 出力は `date` 昇順 → 同一日内は元の並び順を維持。
+
+### 終日イベント
+
+- Google Calendar API の仕様で `end` は **exclusive**（`2026-12-05`〜`2026-12-07` は 12/5・12/6 の2日間）。`dayCount = end - start` 日。
+- ラベルは `dayCount === 1` なら従来どおり `[All Day]`、2日以上なら `[All Day 1/2]` `[All Day 2/2]`。
+
+### 時刻指定イベントの日またぎ
+
+- 各日の**実際の占有時間帯**を表示する。初日 `23:00-24:00` / 翌日 `00:00-01:00` / 中日 `00:00-24:00`。
+- 終了が丁度 00:00 の場合（例 22:00〜翌 00:00）、翌日のグループは**作らない**。
+- 日数カウンタ (`n/m`) は付けない — 切り詰められた時間帯自体が継続を示すため。
+
+### 列幅
+
+`formatTimeRange()` の結果は現在 `padEnd(11)`（`10:00-11:00` = 11文字, `[All Day]` = 9文字）。`[All Day 1/2]` は13文字で溢れるため、**出力内の最長ラベルに合わせた動的幅（最小11）** に変更する。複数日イベントを含まない出力は従来と同じ幅を保つ。
+
+### `--quiet` と `search`
+
+- `formatQuietText(events, range?)` — `range` を渡すと日別展開＋clip（`gcal list --quiet` 用）、省略時は1行1イベント（`gcal search --quiet` 用、従来どおり）。
+- `search` はイベント中心の一覧なので日別展開はしない。代わりに `formatSearchEventLine()` の終日ラベルに期間を併記する（例 `[All Day 12/05-12/06]`）。
+
+### 表示範囲の受け渡し
+
+`handleList()` の `dateRange` (`timeMin` / `timeMax`) から `DayRange` を導出する。`timeMax` は exclusive なので、時刻部が `00:00` なら1日引いた日付を `to` とする。
+
+### 既知の制限
+
+イベント文字列は表示タイムゾーンで整形済みのため日付・時刻の分割は文字列演算で行う。イベント期間中に UTC オフセットが変わる（DST 移行）ケースは考慮しない。
+
+## Implementation Steps
+
+- [ ] `src/lib/event-days.test.ts`: `expandEventsByDay()` の失敗テストを書く（終日単日 / 終日複数日 / clip / 日またぎ時刻 / 終了 00:00 / 3日以上）
+- [ ] `src/lib/event-days.ts`: `expandEventsByDay()` を実装
+- [ ] `src/lib/output.test.ts`: `formatEventListText()` の複数日展開・`[All Day n/m]`・動的列幅の失敗テストを追加
+- [ ] `src/lib/output.ts`: `formatEventListText(events, range?)` を `expandEventsByDay()` ベースに書き換え、グループキーを日付昇順で明示的にソート
+- [ ] `src/lib/output.ts`: `formatTimeRange()` を `EventDay` 対応にし、`[All Day n/m]` を出力
+- [ ] `src/lib/output.test.ts` / `src/lib/output.ts`: `formatQuietText(events, range?)` の日別展開を追加
+- [ ] `src/lib/output.test.ts` / `src/lib/output.ts`: `formatSearchEventLine()` の終日ラベルに期間を併記
+- [ ] `src/commands/list.ts`: `dateRange` から `DayRange` を導出して `formatEventListText` / `formatQuietText` に渡す
+- [ ] `src/commands/list.test.ts`: 2日目単独指定で複数日イベントが表示されることを確認するテストを追加
+- [ ] `spec/output.md`: 複数日イベントの表示例と列幅の説明を追加
+- [ ] `bun run test` pass
+- [ ] `bun run lint` pass
+- [ ] `bun run format:check` pass
+
+## E2E Test
+
+- [ ] 複数日の終日イベントを作成し、`gcal list --from <2日目> --to <2日目>` でそのイベントが表示されること
+- [ ] `gcal list --from <初日> --to <最終日>` で全ての日付グループに `[All Day n/m]` 付きで表示されること
+- [ ] `gcal list -f json` の出力が変わっていないこと
+
+## Acceptance Criteria
+
+- [ ] 複数日にまたがる終日イベントが、占有する全ての日付グループに表示される
+- [ ] 終日ラベルに `[All Day 1/2]` の形式で日目が併記される（単日イベントは `[All Day]` のまま）
+- [ ] 終日イベントの `end` exclusive が正しく扱われる（`12-05`〜`12-07` は2日間）
+- [ ] 表示範囲外の日付グループが生成されない
+- [ ] 日をまたぐ時刻指定イベントが両日に、各日の実占有時間帯で表示される
+- [ ] 終了が丁度 00:00 の時刻指定イベントで翌日のグループが生成されない
+- [ ] `--quiet` 出力でも複数日イベントが全ての日に表示される
+- [ ] `search` の終日イベント行に期間が併記される
+- [ ] JSON 出力は変更されない
+- [ ] 既存テストが pass する
+
+## Out of Scope
+
+- 終日イベントに `[busy]` / `[free]` タグを付ける（#53 の補足で言及。`transparency: transparent` の終日イベントが見落とされやすい問題だが、既存の出力仕様変更を伴うため別タスクとする）

--- a/spec/tasks/ROADMAP.md
+++ b/spec/tasks/ROADMAP.md
@@ -8,6 +8,10 @@ Tasks should be implemented in this order, respecting dependencies within each p
 
 ## In Progress
 
+### Phase 15: Bug Fixes
+
+39. [039-multi-day-event-display](./039-multi-day-event-display.md) — 複数日にまたがるイベントを全ての日付グループに表示 (#53)
+
 ## Completed
 
 ### Phase 14: Google Tasks - Config Integration

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { CalendarEvent, AppConfig } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
-import { resolveDateRange, handleList, createListCommand, type ListHandlerDeps } from "./list.ts";
+import {
+  resolveDateRange,
+  toDayRange,
+  handleList,
+  createListCommand,
+  type ListHandlerDeps,
+} from "./list.ts";
 
 function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   return {
@@ -120,6 +126,35 @@ describe("resolveDateRange", () => {
     expect(() => resolveDateRange({ days: -1 }, tz, now)).toThrow(
       "--days must be a positive integer",
     );
+  });
+});
+
+describe("toDayRange", () => {
+  it("converts an exclusive midnight timeMax to an inclusive last date", () => {
+    expect(
+      toDayRange({
+        timeMin: "2026-12-06T00:00:00+09:00",
+        timeMax: "2026-12-07T00:00:00+09:00",
+      }),
+    ).toEqual({ from: "2026-12-06", to: "2026-12-06" });
+  });
+
+  it("keeps the timeMax date when it carries a time of day", () => {
+    expect(
+      toDayRange({
+        timeMin: "2026-12-06T10:00:00+09:00",
+        timeMax: "2026-12-08T15:00:00+09:00",
+      }),
+    ).toEqual({ from: "2026-12-06", to: "2026-12-08" });
+  });
+
+  it("never returns a range that ends before it starts", () => {
+    expect(
+      toDayRange({
+        timeMin: "2026-12-06T00:00:00+09:00",
+        timeMax: "2026-12-06T00:00:00+09:00",
+      }),
+    ).toEqual({ from: "2026-12-06", to: "2026-12-06" });
   });
 });
 
@@ -462,6 +497,129 @@ describe("handleList", () => {
     const result = await handleList({ today: true, format: "text", quiet: false }, deps);
 
     expect(result.exitCode).toBe(ExitCode.SUCCESS);
+  });
+
+  describe("multi-day events", () => {
+    const course = makeEvent({
+      id: "course",
+      all_day: true,
+      start: "2026-12-05",
+      end: "2026-12-07",
+      title: "Aコース",
+    });
+
+    function makeSingleCalendarDeps(events: CalendarEvent[]) {
+      const write = vi.fn();
+      const deps = makeDeps({
+        listEvents: vi.fn().mockResolvedValue(events),
+        loadConfig: vi
+          .fn()
+          .mockReturnValue(
+            makeConfig({ calendars: [{ id: "primary", name: "Main Calendar", enabled: true }] }),
+          ),
+        write,
+      });
+      return { deps, write };
+    }
+
+    it("shows a spanning all-day event when only its second day is requested", async () => {
+      const { deps, write } = makeSingleCalendarDeps([course]);
+
+      await handleList(
+        {
+          from: "2026-12-06",
+          to: "2026-12-06",
+          format: "text",
+          quiet: false,
+          timezone: "Asia/Tokyo",
+        },
+        deps,
+      );
+
+      const output = write.mock.calls[0]![0] as string;
+      expect(output).toContain("2026-12-06 (Sun)");
+      expect(output).toContain("[All Day 2/2]");
+      expect(output).toContain("Aコース");
+    });
+
+    it("does not render day groups outside the requested range", async () => {
+      const { deps, write } = makeSingleCalendarDeps([course]);
+
+      await handleList(
+        {
+          from: "2026-12-06",
+          to: "2026-12-06",
+          format: "text",
+          quiet: false,
+          timezone: "Asia/Tokyo",
+        },
+        deps,
+      );
+
+      const output = write.mock.calls[0]![0] as string;
+      expect(output).not.toContain("2026-12-05");
+      expect(output).not.toContain("2026-12-07");
+    });
+
+    it("shows the event under every occupied day of a wider range", async () => {
+      const { deps, write } = makeSingleCalendarDeps([course]);
+
+      await handleList(
+        {
+          from: "2026-12-04",
+          to: "2026-12-07",
+          format: "text",
+          quiet: false,
+          timezone: "Asia/Tokyo",
+        },
+        deps,
+      );
+
+      const output = write.mock.calls[0]![0] as string;
+      expect(output).toContain("2026-12-05 (Sat)");
+      expect(output).toContain("[All Day 1/2]");
+      expect(output).toContain("2026-12-06 (Sun)");
+      expect(output).toContain("[All Day 2/2]");
+    });
+
+    it("expands multi-day events in --quiet output too", async () => {
+      const { deps, write } = makeSingleCalendarDeps([course]);
+
+      await handleList(
+        {
+          from: "2026-12-04",
+          to: "2026-12-07",
+          format: "text",
+          quiet: true,
+          timezone: "Asia/Tokyo",
+        },
+        deps,
+      );
+
+      const output = write.mock.calls[0]![0] as string;
+      expect(output).toContain("12/05 All day");
+      expect(output).toContain("12/06 All day");
+    });
+
+    it("leaves JSON output untouched", async () => {
+      const { deps, write } = makeSingleCalendarDeps([course]);
+
+      await handleList(
+        {
+          from: "2026-12-06",
+          to: "2026-12-06",
+          format: "json",
+          quiet: false,
+          timezone: "Asia/Tokyo",
+        },
+        deps,
+      );
+
+      const output = JSON.parse(write.mock.calls[0]![0] as string);
+      expect(output.data.count).toBe(1);
+      expect(output.data.events[0].start).toBe("2026-12-05");
+      expect(output.data.events[0].end).toBe("2026-12-07");
+    });
   });
 });
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -6,6 +6,8 @@ import { resolveTimezone, formatDateTimeInZone, parseDateTimeInZone } from "../l
 import { selectCalendars } from "../lib/config.ts";
 import { applyFilters } from "../lib/filter.ts";
 import { formatEventListText, formatJsonSuccess, formatQuietText } from "../lib/output.ts";
+import type { DayRange } from "../lib/event-days.ts";
+import { addDaysToDateString } from "../lib/date-utils.ts";
 import { collect } from "./shared.ts";
 import { addDays } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
@@ -77,6 +79,20 @@ export function resolveDateRange(
     timeMin: formatDateTimeInZone(todayStart, timezone),
     timeMax: formatDateTimeInZone(end, timezone),
   };
+}
+
+/**
+ * Convert the API query window into the inclusive range of calendar dates the
+ * text output should cover. `timeMax` is exclusive, so a midnight boundary
+ * belongs to the previous day.
+ */
+export function toDayRange(range: Pick<DateRange, "timeMin" | "timeMax">): DayRange {
+  const from = range.timeMin.slice(0, 10);
+  const endsAtMidnight = range.timeMax.slice(11, 16) === "00:00";
+  const to = endsAtMidnight
+    ? addDaysToDateString(range.timeMax.slice(0, 10), -1)
+    : range.timeMax.slice(0, 10);
+  return { from, to: to < from ? from : to };
 }
 
 export interface ListHandlerDeps {
@@ -167,11 +183,14 @@ export async function handleList(
   // Output
   if (options.format === "json") {
     deps.write(formatJsonSuccess({ events: filtered, count: filtered.length }));
-  } else if (options.quiet) {
-    deps.write(formatQuietText(filtered));
   } else {
-    const text = formatEventListText(filtered);
-    deps.write(text || "No events found.");
+    const dayRange = toDayRange(dateRange);
+    if (options.quiet) {
+      deps.write(formatQuietText(filtered, dayRange));
+    } else {
+      const text = formatEventListText(filtered, dayRange);
+      deps.write(text || "No events found.");
+    }
   }
 
   return { exitCode: ExitCode.SUCCESS };

--- a/src/lib/event-days.test.ts
+++ b/src/lib/event-days.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "../types/index.ts";
+import { expandEventsByDay } from "./event-days.ts";
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "test-id",
+    title: "Test Event",
+    description: null,
+    start: "2026-01-24T10:00:00+09:00",
+    end: "2026-01-24T11:00:00+09:00",
+    all_day: false,
+    calendar_id: "primary",
+    calendar_name: "Main Calendar",
+    html_link: "https://calendar.google.com/event?id=test",
+    status: "confirmed",
+    transparency: "opaque",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("expandEventsByDay", () => {
+  describe("all-day events", () => {
+    it("expands a single-day all-day event to one entry", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-06" });
+      const result = expandEventsByDay([event]);
+      expect(result).toEqual([
+        { date: "2026-12-05", event, dayIndex: 1, dayCount: 1, startTime: "", endTime: "" },
+      ]);
+    });
+
+    it("expands a two-day all-day event to both days (end is exclusive)", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-07" });
+      const result = expandEventsByDay([event]);
+      expect(result.map((d) => d.date)).toEqual(["2026-12-05", "2026-12-06"]);
+      expect(result.map((d) => d.dayIndex)).toEqual([1, 2]);
+      expect(result.every((d) => d.dayCount === 2)).toBe(true);
+    });
+
+    it("expands an all-day event spanning a month boundary", () => {
+      const event = makeEvent({ all_day: true, start: "2026-11-29", end: "2026-12-02" });
+      const result = expandEventsByDay([event]);
+      expect(result.map((d) => d.date)).toEqual(["2026-11-29", "2026-11-30", "2026-12-01"]);
+      expect(result.map((d) => d.dayIndex)).toEqual([1, 2, 3]);
+      expect(result.every((d) => d.dayCount === 3)).toBe(true);
+    });
+
+    it("treats a malformed all-day event with end <= start as a single day", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-05" });
+      const result = expandEventsByDay([event]);
+      expect(result.map((d) => d.date)).toEqual(["2026-12-05"]);
+      expect(result[0]?.dayCount).toBe(1);
+    });
+  });
+
+  describe("timed events", () => {
+    it("expands a same-day timed event to one entry with its own times", () => {
+      const event = makeEvent({
+        start: "2026-12-05T10:00:00+09:00",
+        end: "2026-12-05T11:00:00+09:00",
+      });
+      const result = expandEventsByDay([event]);
+      expect(result).toEqual([
+        {
+          date: "2026-12-05",
+          event,
+          dayIndex: 1,
+          dayCount: 1,
+          startTime: "10:00",
+          endTime: "11:00",
+        },
+      ]);
+    });
+
+    it("splits an event crossing midnight into each day's occupied range", () => {
+      const event = makeEvent({
+        start: "2026-12-05T23:00:00+09:00",
+        end: "2026-12-06T01:00:00+09:00",
+      });
+      const result = expandEventsByDay([event]);
+      expect(result).toEqual([
+        {
+          date: "2026-12-05",
+          event,
+          dayIndex: 1,
+          dayCount: 2,
+          startTime: "23:00",
+          endTime: "24:00",
+        },
+        {
+          date: "2026-12-06",
+          event,
+          dayIndex: 2,
+          dayCount: 2,
+          startTime: "00:00",
+          endTime: "01:00",
+        },
+      ]);
+    });
+
+    it("gives full-day ranges to middle days of a multi-day timed event", () => {
+      const event = makeEvent({
+        start: "2026-12-05T23:00:00+09:00",
+        end: "2026-12-08T01:00:00+09:00",
+      });
+      const result = expandEventsByDay([event]);
+      expect(result.map((d) => [d.date, d.startTime, d.endTime])).toEqual([
+        ["2026-12-05", "23:00", "24:00"],
+        ["2026-12-06", "00:00", "24:00"],
+        ["2026-12-07", "00:00", "24:00"],
+        ["2026-12-08", "00:00", "01:00"],
+      ]);
+    });
+
+    it("does not create a group for the next day when the event ends at midnight", () => {
+      const event = makeEvent({
+        start: "2026-12-05T22:00:00+09:00",
+        end: "2026-12-06T00:00:00+09:00",
+      });
+      const result = expandEventsByDay([event]);
+      expect(result).toEqual([
+        {
+          date: "2026-12-05",
+          event,
+          dayIndex: 1,
+          dayCount: 1,
+          startTime: "22:00",
+          endTime: "24:00",
+        },
+      ]);
+    });
+
+    it("keeps a zero-length event at midnight on its own day", () => {
+      const event = makeEvent({
+        start: "2026-12-05T00:00:00+09:00",
+        end: "2026-12-05T00:00:00+09:00",
+      });
+      const result = expandEventsByDay([event]);
+      expect(result.map((d) => [d.date, d.startTime, d.endTime])).toEqual([
+        ["2026-12-05", "00:00", "00:00"],
+      ]);
+    });
+  });
+
+  describe("range clipping", () => {
+    it("drops days outside the range but keeps the original day numbering", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08" });
+      const result = expandEventsByDay([event], { from: "2026-12-06", to: "2026-12-06" });
+      expect(result).toEqual([
+        { date: "2026-12-06", event, dayIndex: 2, dayCount: 3, startTime: "", endTime: "" },
+      ]);
+    });
+
+    it("returns nothing when the event falls entirely outside the range", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-06" });
+      const result = expandEventsByDay([event], { from: "2026-12-10", to: "2026-12-12" });
+      expect(result).toEqual([]);
+    });
+
+    it("keeps every day when the range covers the whole event", () => {
+      const event = makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-07" });
+      const result = expandEventsByDay([event], { from: "2026-12-01", to: "2026-12-31" });
+      expect(result.map((d) => d.date)).toEqual(["2026-12-05", "2026-12-06"]);
+    });
+  });
+
+  describe("ordering", () => {
+    it("sorts entries by date ascending", () => {
+      const spanning = makeEvent({
+        id: "spanning",
+        all_day: true,
+        start: "2026-12-05",
+        end: "2026-12-08",
+      });
+      const later = makeEvent({
+        id: "later",
+        start: "2026-12-06T09:00:00+09:00",
+        end: "2026-12-06T10:00:00+09:00",
+      });
+      const result = expandEventsByDay([spanning, later]);
+      expect(result.map((d) => [d.date, d.event.id])).toEqual([
+        ["2026-12-05", "spanning"],
+        ["2026-12-06", "spanning"],
+        ["2026-12-06", "later"],
+        ["2026-12-07", "spanning"],
+      ]);
+    });
+
+    it("preserves input order among events on the same date", () => {
+      const first = makeEvent({
+        id: "first",
+        start: "2026-12-05T09:00:00+09:00",
+        end: "2026-12-05T10:00:00+09:00",
+      });
+      const second = makeEvent({
+        id: "second",
+        start: "2026-12-05T11:00:00+09:00",
+        end: "2026-12-05T12:00:00+09:00",
+      });
+      const result = expandEventsByDay([first, second]);
+      expect(result.map((d) => d.event.id)).toEqual(["first", "second"]);
+    });
+
+    it("returns an empty array for no events", () => {
+      expect(expandEventsByDay([])).toEqual([]);
+    });
+  });
+});

--- a/src/lib/event-days.ts
+++ b/src/lib/event-days.ts
@@ -1,0 +1,110 @@
+import type { CalendarEvent } from "../types/index.ts";
+import { addDaysToDateString } from "./date-utils.ts";
+
+/** Inclusive range of calendar dates (YYYY-MM-DD) to display. */
+export interface DayRange {
+  from: string;
+  to: string;
+}
+
+/** One calendar day occupied by an event. */
+export interface EventDay {
+  date: string;
+  event: CalendarEvent;
+  /** 1-based position within the event's own span, independent of any clipping. */
+  dayIndex: number;
+  /** Total number of days the event occupies. */
+  dayCount: number;
+  /** "HH:MM" the event occupies from on this day; "" for all-day events. */
+  startTime: string;
+  /** "HH:MM" the event occupies until on this day ("24:00" when it continues); "" for all-day events. */
+  endTime: string;
+}
+
+const DAY_START = "00:00";
+const DAY_END = "24:00";
+
+function daysBetween(from: string, to: string): number {
+  const start = Date.parse(from + "T00:00:00Z");
+  const end = Date.parse(to + "T00:00:00Z");
+  return Math.round((end - start) / 86_400_000);
+}
+
+interface Span {
+  lastDate: string;
+  firstStartTime: string;
+  lastEndTime: string;
+}
+
+/**
+ * Resolve the last calendar date an event occupies, plus its times on the
+ * boundary days. Event date strings are already formatted in the display
+ * timezone, so plain string arithmetic is enough.
+ */
+function resolveSpan(event: CalendarEvent): Span {
+  const startDate = event.start.slice(0, 10);
+
+  if (event.all_day) {
+    // The API reports all-day `end` as exclusive: 12-05..12-07 is two days.
+    const lastDate = addDaysToDateString(event.end, -1);
+    return {
+      lastDate: lastDate < startDate ? startDate : lastDate,
+      firstStartTime: "",
+      lastEndTime: "",
+    };
+  }
+
+  const endDate = event.end.slice(0, 10);
+  const endTime = event.end.slice(11, 16);
+  const firstStartTime = event.start.slice(11, 16);
+
+  // An event ending exactly at midnight does not occupy the following day.
+  if (endTime === DAY_START) {
+    const lastDate = addDaysToDateString(endDate, -1);
+    if (lastDate >= startDate) {
+      return { lastDate, firstStartTime, lastEndTime: DAY_END };
+    }
+    return { lastDate: startDate, firstStartTime, lastEndTime: endTime };
+  }
+
+  return {
+    lastDate: endDate < startDate ? startDate : endDate,
+    firstStartTime,
+    lastEndTime: endTime,
+  };
+}
+
+/**
+ * Expand each event into one entry per calendar day it occupies, sorted by
+ * date. Events on the same date keep their input order. When `range` is given,
+ * days outside it are dropped while `dayIndex`/`dayCount` still describe the
+ * full event.
+ */
+export function expandEventsByDay(events: CalendarEvent[], range?: DayRange): EventDay[] {
+  const days: EventDay[] = [];
+
+  for (const event of events) {
+    const startDate = event.start.slice(0, 10);
+    const { lastDate, firstStartTime, lastEndTime } = resolveSpan(event);
+    const dayCount = daysBetween(startDate, lastDate) + 1;
+
+    for (let i = 0; i < dayCount; i++) {
+      const date = addDaysToDateString(startDate, i);
+      if (range && (date < range.from || date > range.to)) continue;
+
+      const isFirst = i === 0;
+      const isLast = i === dayCount - 1;
+      days.push({
+        date,
+        event,
+        dayIndex: i + 1,
+        dayCount,
+        startTime: event.all_day ? "" : isFirst ? firstStartTime : DAY_START,
+        endTime: event.all_day ? "" : isLast ? lastEndTime : DAY_END,
+      });
+    }
+  }
+
+  // Array.prototype.sort is stable, so same-date entries keep their input order.
+  return days.sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -214,6 +214,120 @@ describe("formatEventListText", () => {
     ].join("\n");
     expect(result).toBe(expected);
   });
+
+  describe("multi-day events", () => {
+    it("shows a multi-day all-day event under every day it occupies", () => {
+      const events = [
+        makeEvent({
+          all_day: true,
+          start: "2026-12-05",
+          end: "2026-12-07",
+          title: "Aコース",
+        }),
+      ];
+      const result = formatEventListText(events);
+      const expected = [
+        "2026-12-05 (Sat)",
+        "  [All Day 1/2]   Aコース (Main Calendar)",
+        "",
+        "2026-12-06 (Sun)",
+        "  [All Day 2/2]   Aコース (Main Calendar)",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("keeps [All Day] without a counter for single-day all-day events", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-06", title: "Holiday" }),
+      ];
+      expect(formatEventListText(events)).toContain("[All Day]  ");
+      expect(formatEventListText(events)).not.toContain("1/1");
+    });
+
+    it("widens the time column so multi-day labels stay aligned", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-07", title: "Aコース" }),
+        makeEvent({
+          start: "2026-12-05T10:00:00+09:00",
+          end: "2026-12-05T11:00:00+09:00",
+          title: "Team Meeting",
+        }),
+      ];
+      const result = formatEventListText(events);
+      const expected = [
+        "2026-12-05 (Sat)",
+        "  [All Day 1/2]   Aコース (Main Calendar)",
+        "  10:00-11:00     Team Meeting (Main Calendar) [busy]",
+        "",
+        "2026-12-06 (Sun)",
+        "  [All Day 2/2]   Aコース (Main Calendar)",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("splits a timed event crossing midnight into each day's occupied range", () => {
+      const events = [
+        makeEvent({
+          start: "2026-12-05T23:00:00+09:00",
+          end: "2026-12-06T01:00:00+09:00",
+          title: "Night Shift",
+        }),
+      ];
+      const result = formatEventListText(events);
+      const expected = [
+        "2026-12-05 (Sat)",
+        "  23:00-24:00   Night Shift (Main Calendar) [busy]",
+        "",
+        "2026-12-06 (Sun)",
+        "  00:00-01:00   Night Shift (Main Calendar) [busy]",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("orders day groups chronologically when a span interleaves other events", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08", title: "Aコース" }),
+        makeEvent({
+          start: "2026-12-06T09:00:00+09:00",
+          end: "2026-12-06T10:00:00+09:00",
+          title: "Team Meeting",
+        }),
+      ];
+      const result = formatEventListText(events);
+      const dayHeaders = result.split("\n").filter((line) => line.startsWith("2026-"));
+      expect(dayHeaders).toEqual(["2026-12-05 (Sat)", "2026-12-06 (Sun)", "2026-12-07 (Mon)"]);
+      expect(result).toContain("  [All Day 2/3]   Aコース (Main Calendar)");
+      expect(result).toContain("  09:00-10:00     Team Meeting (Main Calendar) [busy]");
+    });
+  });
+
+  describe("range clipping", () => {
+    it("shows only the requested day but keeps the original day number", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08", title: "Aコース" }),
+      ];
+      const result = formatEventListText(events, { from: "2026-12-06", to: "2026-12-06" });
+      const expected = ["2026-12-06 (Sun)", "  [All Day 2/3]   Aコース (Main Calendar)"].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("does not create day groups outside the range", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08", title: "Aコース" }),
+      ];
+      const result = formatEventListText(events, { from: "2026-12-06", to: "2026-12-07" });
+      expect(result).not.toContain("2026-12-05");
+      expect(result).toContain("2026-12-06");
+      expect(result).toContain("2026-12-07");
+    });
+
+    it("returns an empty string when nothing falls inside the range", () => {
+      const events = [
+        makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-06", title: "Aコース" }),
+      ];
+      expect(formatEventListText(events, { from: "2026-12-10", to: "2026-12-12" })).toBe("");
+    });
+  });
 });
 
 describe("formatSearchResultText", () => {
@@ -292,6 +406,45 @@ describe("formatSearchResultText", () => {
     ];
     const result = formatSearchResultText("holiday", events);
     expect(result).toContain("2026-01-24 [All Day]    Company Holiday (Main Calendar)");
+  });
+
+  it("annotates the period on multi-day all-day events", () => {
+    const events = [
+      makeEvent({
+        all_day: true,
+        start: "2026-12-05",
+        end: "2026-12-07",
+        title: "Aコース",
+        calendar_name: "Main Calendar",
+      }),
+    ];
+    const result = formatSearchResultText("A", events);
+    expect(result).toContain("2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar)");
+  });
+
+  it("annotates the end date on timed events crossing midnight", () => {
+    const events = [
+      makeEvent({
+        start: "2026-12-05T23:00:00+09:00",
+        end: "2026-12-06T01:00:00+09:00",
+        title: "Night Shift",
+        calendar_name: "Main Calendar",
+      }),
+    ];
+    const result = formatSearchResultText("night", events);
+    expect(result).toContain("2026-12-05 23:00-12/06 01:00  Night Shift (Main Calendar) [busy]");
+  });
+
+  it("keeps single-day rows unpadded when no multi-day event is present", () => {
+    const events = [
+      makeEvent({
+        start: "2026-01-24T10:00:00+09:00",
+        end: "2026-01-24T11:00:00+09:00",
+        title: "Team Meeting",
+      }),
+    ];
+    const result = formatSearchResultText("meeting", events);
+    expect(result).toContain("2026-01-24 10:00-11:00  Team Meeting (Main Calendar) [busy]");
   });
 
   it("returns no-results message for empty list", () => {
@@ -498,6 +651,52 @@ describe("formatQuietText", () => {
     const result = formatQuietText(events);
     expect(result).toContain("01/24 10:00-11:00  Meeting");
     expect(result).toContain("01/25 14:00-15:00  Review");
+  });
+
+  it("keeps one line per event when no range is given (search)", () => {
+    const events = [
+      makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-07", title: "Aコース" }),
+    ];
+    expect(formatQuietText(events)).toBe("12/05 All day      Aコース");
+  });
+
+  it("expands multi-day events to one line per day when a range is given", () => {
+    const events = [
+      makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-07", title: "Aコース" }),
+    ];
+    const result = formatQuietText(events, { from: "2026-12-01", to: "2026-12-31" });
+    expect(result).toBe(["12/05 All day      Aコース", "12/06 All day      Aコース"].join("\n"));
+  });
+
+  it("clips expanded days to the range", () => {
+    const events = [
+      makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08", title: "Aコース" }),
+    ];
+    const result = formatQuietText(events, { from: "2026-12-06", to: "2026-12-06" });
+    expect(result).toBe("12/06 All day      Aコース");
+  });
+
+  it("shows each day's occupied range for a timed event crossing midnight", () => {
+    const events = [
+      makeEvent({
+        start: "2026-12-05T23:00:00+09:00",
+        end: "2026-12-06T01:00:00+09:00",
+        title: "Night Shift",
+      }),
+    ];
+    const result = formatQuietText(events, { from: "2026-12-01", to: "2026-12-31" });
+    expect(result).toBe(
+      ["12/05 23:00-24:00  Night Shift", "12/06 00:00-01:00  Night Shift"].join("\n"),
+    );
+  });
+
+  it("returns 'No events found.' when the range excludes everything", () => {
+    const events = [
+      makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-06", title: "Aコース" }),
+    ];
+    expect(formatQuietText(events, { from: "2026-12-10", to: "2026-12-12" })).toBe(
+      "No events found.",
+    );
   });
 });
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,5 +1,8 @@
 import type { Calendar, CalendarEvent, ErrorCode } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
+import { expandEventsByDay, type DayRange, type EventDay } from "./event-days.ts";
+
+export type { DayRange } from "./event-days.ts";
 
 export function formatJsonSuccess(data: unknown): string {
   return JSON.stringify({ success: true, data }, null, 2);
@@ -11,73 +14,95 @@ export function formatJsonError(code: ErrorCode, message: string): string {
 
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 
-function getDateKey(event: CalendarEvent): string {
-  if (event.all_day) {
-    return event.start;
-  }
-  return event.start.slice(0, 10);
-}
+/** Width of `HH:MM-HH:MM`; wider labels grow the column for the whole output. */
+const TIME_COL_MIN_WIDTH = 11;
 
 function getDayOfWeek(dateStr: string): string {
   const date = new Date(dateStr + "T00:00:00Z");
   return DAY_NAMES[date.getUTCDay()] ?? "???";
 }
 
-export function formatTimeRange(event: CalendarEvent): string {
-  if (event.all_day) {
-    return "[All Day]";
+/** "2026-12-06" -> "12/06" */
+function toMonthDay(dateStr: string): string {
+  return `${dateStr.slice(5, 7)}/${dateStr.slice(8, 10)}`;
+}
+
+function timeColumnWidth(labels: string[]): number {
+  return Math.max(TIME_COL_MIN_WIDTH, ...labels.map((label) => label.length));
+}
+
+/**
+ * Label for one day of an event: the portion of that day the event occupies,
+ * or `[All Day n/m]` when an all-day event spans several days.
+ */
+export function formatTimeRange(day: EventDay): string {
+  if (day.event.all_day) {
+    return day.dayCount === 1 ? "[All Day]" : `[All Day ${day.dayIndex}/${day.dayCount}]`;
   }
-  const startTime = event.start.slice(11, 16);
-  const endTime = event.end.slice(11, 16);
-  return `${startTime}-${endTime}`;
+  return `${day.startTime}-${day.endTime}`;
+}
+
+/**
+ * Label for a whole event on a single line. Search lists one row per event
+ * rather than per day, so a multi-day span is annotated inline.
+ */
+function formatEventSpanLabel(event: CalendarEvent): string {
+  const days = expandEventsByDay([event]);
+  const first = days[0];
+  const last = days[days.length - 1];
+  if (!first || !last) return "";
+
+  if (event.all_day) {
+    return days.length === 1
+      ? "[All Day]"
+      : `[All Day ${toMonthDay(first.date)}-${toMonthDay(last.date)}]`;
+  }
+  return first.date === last.date
+    ? `${first.startTime}-${last.endTime}`
+    : `${first.startTime}-${toMonthDay(last.date)} ${last.endTime}`;
 }
 
 function transparencyTag(event: CalendarEvent): string {
   return event.transparency === "transparent" ? "[free]" : "[busy]";
 }
 
-export function formatEventListText(events: CalendarEvent[]): string {
-  if (events.length === 0) return "";
+/**
+ * Group events by the days they occupy. Events spanning several days appear
+ * under each of them; `range` limits which days are rendered.
+ */
+export function formatEventListText(events: CalendarEvent[], range?: DayRange): string {
+  const days = expandEventsByDay(events, range);
+  if (days.length === 0) return "";
 
-  const groups = new Map<string, CalendarEvent[]>();
-  for (const event of events) {
-    const key = getDateKey(event);
-    const group = groups.get(key);
+  const labels = days.map(formatTimeRange);
+  const width = timeColumnWidth(labels);
+
+  const groups = new Map<string, string[]>();
+  for (let i = 0; i < days.length; i++) {
+    const day = days[i]!;
+    const { event } = day;
+    const time = labels[i]!.padEnd(width);
+    const tag = event.all_day ? "" : ` ${transparencyTag(event)}`;
+    const line = `  ${time}   ${event.title} (${event.calendar_name})${tag}`;
+
+    const group = groups.get(day.date);
     if (group) {
-      group.push(event);
+      group.push(line);
     } else {
-      groups.set(key, [event]);
+      groups.set(day.date, [line]);
     }
   }
 
   const lines: string[] = [];
   let first = true;
-  for (const [dateKey, groupEvents] of groups) {
+  for (const [date, groupLines] of groups) {
     if (!first) lines.push("");
     first = false;
-    lines.push(`${dateKey} (${getDayOfWeek(dateKey)})`);
-    for (const event of groupEvents) {
-      const time = formatTimeRange(event).padEnd(11);
-      if (event.all_day) {
-        lines.push(`  ${time}   ${event.title} (${event.calendar_name})`);
-      } else {
-        const tag = transparencyTag(event);
-        lines.push(`  ${time}   ${event.title} (${event.calendar_name}) ${tag}`);
-      }
-    }
+    lines.push(`${date} (${getDayOfWeek(date)})`);
+    lines.push(...groupLines);
   }
 
   return lines.join("\n");
-}
-
-function formatSearchEventLine(event: CalendarEvent): string {
-  const date = getDateKey(event);
-  const time = formatTimeRange(event).padEnd(11);
-  if (event.all_day) {
-    return `${date} ${time}  ${event.title} (${event.calendar_name})`;
-  }
-  const tag = transparencyTag(event);
-  return `${date} ${time}  ${event.title} (${event.calendar_name}) ${tag}`;
 }
 
 export function formatSearchResultText(query: string, events: CalendarEvent[]): string {
@@ -85,31 +110,51 @@ export function formatSearchResultText(query: string, events: CalendarEvent[]): 
   const plural = count === 1 ? "event" : "events";
   if (count === 0) return `Found 0 events matching "${query}".`;
 
-  const header = `Found ${count} ${plural} matching "${query}":`;
+  const labels = events.map(formatEventSpanLabel);
+  const width = timeColumnWidth(labels);
 
-  const lines = [header, ""];
-  for (const event of events) {
-    lines.push(formatSearchEventLine(event));
+  const lines = [`Found ${count} ${plural} matching "${query}":`, ""];
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i]!;
+    const date = event.start.slice(0, 10);
+    const time = labels[i]!.padEnd(width);
+    const tag = event.all_day ? "" : ` ${transparencyTag(event)}`;
+    lines.push(`${date} ${time}  ${event.title} (${event.calendar_name})${tag}`);
   }
   return lines.join("\n");
 }
 
-export function formatQuietText(events: CalendarEvent[]): string {
-  if (events.length === 0) return "No events found.";
+interface QuietRow {
+  date: string;
+  label: string;
+  title: string;
+}
 
-  const lines: string[] = [];
-  for (const event of events) {
-    const month = event.start.slice(5, 7);
-    const day = event.start.slice(8, 10);
-    const datePrefix = `${month}/${day}`;
-    if (event.all_day) {
-      lines.push(`${datePrefix} All day      ${event.title}`);
-    } else {
-      const time = formatTimeRange(event);
-      lines.push(`${datePrefix} ${time}  ${event.title}`);
-    }
-  }
-  return lines.join("\n");
+/**
+ * Minimal one-line-per-entry output. Passing `range` switches to a day-oriented
+ * view where multi-day events get a line per day; without it each event is
+ * listed once (used by search).
+ */
+export function formatQuietText(events: CalendarEvent[], range?: DayRange): string {
+  const rows: QuietRow[] = range
+    ? expandEventsByDay(events, range).map((day) => ({
+        date: day.date,
+        label: day.event.all_day ? "All day" : `${day.startTime}-${day.endTime}`,
+        title: day.event.title,
+      }))
+    : events.map((event) => ({
+        date: event.start.slice(0, 10),
+        label: event.all_day
+          ? "All day"
+          : `${event.start.slice(11, 16)}-${event.end.slice(11, 16)}`,
+        title: event.title,
+      }));
+
+  if (rows.length === 0) return "No events found.";
+
+  return rows
+    .map((row) => `${toMonthDay(row.date)} ${row.label.padEnd(TIME_COL_MIN_WIDTH)}  ${row.title}`)
+    .join("\n");
 }
 
 const CALENDAR_ID_MAX = 15;

--- a/tests/e2e/multi-day-events.test.ts
+++ b/tests/e2e/multi-day-events.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterAll } from "vitest";
+import {
+  runCli,
+  runCliJson,
+  testEventTitle,
+  todayDate,
+  TestCleanup,
+  hasCredentials,
+  retryUntil,
+} from "./helpers.ts";
+
+const creds = hasCredentials();
+
+/** YYYY-MM-DD `days` after today, in local time. */
+function dateOffset(days: number): string {
+  const [y, m, d] = todayDate().split("-").map(Number);
+  const date = new Date(y!, m! - 1, d! + days);
+  const yy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+// Far enough out that unrelated events are unlikely to share these days.
+const day1 = dateOffset(40);
+const day2 = dateOffset(41);
+const day3 = dateOffset(42);
+
+describe.runIf(creds)("E2E: multi-day all-day events", () => {
+  const cleanup = new TestCleanup();
+
+  afterAll(async () => {
+    await cleanup.deleteAll();
+  });
+
+  const title = testEventTitle("MultiDay");
+
+  it("add creates a two-day all-day event", async () => {
+    // All-day --end is inclusive on input, so day1..day2 is a two-day event.
+    const { json, result } = await runCliJson(
+      "add",
+      "--title",
+      title,
+      "--start",
+      day1,
+      "--end",
+      day2,
+    );
+
+    expect(result.exitCode).toBe(0);
+    const data = json as { success: boolean; data: { event: { id: string; all_day: boolean } } };
+    expect(data.success).toBe(true);
+    expect(data.data.event.all_day).toBe(true);
+    cleanup.track(data.data.event.id);
+  });
+
+  it("list shows the event when only its second day is requested", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day2, "--to", day2);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(title);
+      expect(result.stdout).toContain("[All Day 2/2]");
+    });
+  });
+
+  it("list shows the event under every day of a wider range", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day1, "--to", day3);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`${day1} (`);
+      expect(result.stdout).toContain("[All Day 1/2]");
+      expect(result.stdout).toContain(`${day2} (`);
+      expect(result.stdout).toContain("[All Day 2/2]");
+    });
+  });
+
+  it("list does not render day groups outside the requested range", async () => {
+    const result = await runCli("list", "--from", day2, "--to", day2);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain(day1);
+    expect(result.stdout).not.toContain(day3);
+  });
+
+  it("list --quiet repeats the event on each occupied day", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--quiet", "--from", day1, "--to", day3);
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.split("\n").filter((line) => line.includes(title));
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain(`${day1.slice(5, 7)}/${day1.slice(8, 10)}`);
+      expect(lines[1]).toContain(`${day2.slice(5, 7)}/${day2.slice(8, 10)}`);
+    });
+  });
+
+  it("list -f json still reports the event once with its original span", async () => {
+    await retryUntil(async () => {
+      const { json, result } = await runCliJson("list", "--from", day2, "--to", day2);
+      expect(result.exitCode).toBe(0);
+
+      const data = json as {
+        data: { events: { title: string; start: string; end: string; all_day: boolean }[] };
+      };
+      const matches = data.data.events.filter((event) => event.title === title);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.start).toBe(day1);
+      // The API reports all-day end as exclusive.
+      expect(matches[0]!.end).toBe(day3);
+    });
+  });
+});
+
+describe.runIf(creds)("E2E: timed events crossing midnight", () => {
+  const cleanup = new TestCleanup();
+
+  afterAll(async () => {
+    await cleanup.deleteAll();
+  });
+
+  const title = testEventTitle("Overnight");
+
+  it("add creates an event spanning midnight", async () => {
+    const { json, result } = await runCliJson(
+      "add",
+      "--title",
+      title,
+      "--start",
+      `${day1}T23:00`,
+      "--end",
+      `${day2}T01:00`,
+    );
+
+    expect(result.exitCode).toBe(0);
+    const data = json as { success: boolean; data: { event: { id: string } } };
+    expect(data.success).toBe(true);
+    cleanup.track(data.data.event.id);
+  });
+
+  it("list shows each day's occupied range", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day1, "--to", day2);
+      expect(result.exitCode).toBe(0);
+
+      const lines = result.stdout.split("\n").filter((line) => line.includes(title));
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain("23:00-24:00");
+      expect(lines[1]).toContain("00:00-01:00");
+    });
+  });
+
+  it("list shows the event when only the second day is requested", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day2, "--to", day2);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(title);
+      expect(result.stdout).toContain("00:00-01:00");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #53

## 問題

テキスト出力がイベントを **start の日付だけ** でグループ化していたため、複数日にまたがる終日イベントが2日目以降に表示されなかった。2日目を単独指定すると何も出力されず、埋まっている日が空きに見える。

```console
$ gcal list --from 2026-12-06 --to 2026-12-06
（何も出力されない）   # ← 12/05-12/07 の終日イベントが存在するのに
```

## 変更

- **`src/lib/event-days.ts` (新規)** — `expandEventsByDay(events, range?)`。イベントを占有日ごとに展開する純粋関数。終日 `end` の exclusive を正しく扱い、日をまたぐ時刻指定イベントを分割する。`range` で範囲外の日を切り落としつつ `dayIndex`/`dayCount` はイベント全体を指したまま保つ。
- **`formatEventListText` / `formatQuietText`** — 展開結果でグループ化。複数日の終日イベントは `[All Day n/m]`、日またぎの時刻イベントは各日の実占有時間帯（`23:00-24:00` → `00:00-01:00`）で表示。
- **時刻カラム幅** — 出力内の最長ラベルに合わせて動的化（最小11）。複数日イベントを含まない出力は従来と同じ幅。
- **`search`** — イベント中心の一覧なので日別展開はせず、期間をラベルに併記（`[All Day 12/05-12/06]` / `23:00-12/06 01:00`）。
- **`toDayRange()`** — `--from`/`--to` から導いた API クエリ範囲（`timeMax` は exclusive）を表示日レンジに変換。

JSON 出力は変更なし。

## 実カレンダーでの Before / After

```
# Before
2026-09-05 (Sat)
  [All Day]     日本看護研究学会第52回学術集会
  [All Day]     Stay at ホテルココ・グラン高崎
                                          ← 9/6 には出ない

# After
2026-09-05 (Sat)
  [All Day 1/2]   日本看護研究学会第52回学術集会 (ncukondo@gmail.com)
  [All Day]       【宿泊】ホテルココ・グラン高崎（朝食付） (ncukondo@gmail.com)
  [All Day 1/2]   Stay at ホテルココ・グラン高崎 (ncukondo@gmail.com)

2026-09-06 (Sun)
  [All Day 2/2]   日本看護研究学会第52回学術集会 (ncukondo@gmail.com)
  [All Day 2/2]   Stay at ホテルココ・グラン高崎 (ncukondo@gmail.com)
  09:00-09:20     座長・演者受付 (ncukondo@gmail.com) [busy]
```

## テスト

TDD (Red → Green)。すべて pass。lint・format:check・typecheck も pass。

| suite | 件数 |
|---|---|
| unit | 677 |
| integration | 72 |
| **e2e（実 API）** | **31** |

- `src/lib/event-days.test.ts` — 15件（終日単日/複数日、月跨ぎ、range clip、日またぎ分割、終了00:00、並び順）
- `src/lib/output.test.ts` — 複数日展開・カウンタ・列幅・quiet 展開・search 期間併記
- `src/commands/list.test.ts` — `toDayRange()` と、2日目単独指定でイベントが表示されること
- `tests/e2e/multi-day-events.test.ts`（新規, 9件） — 実カレンダーに2日間の終日イベントと日またぎイベントを作成し、2日目単独指定での表示・範囲外グループが出ないこと・`--quiet` の日別展開・JSON が1件のまま元の span を保つことを検証（`TestCleanup` で削除）

## 付随修正: `test:e2e` が起動していなかった

`tests/e2e/helpers.ts` は `Bun.spawn` を使うが `vitest` は Node で動くため、E2E スイート全体が `ReferenceError: Bun is not defined` で 22/22 失敗していた（**本 PR 以前からの不具合**、main でも再現）。`package.json` の `test:e2e` を `bun run --bun vitest run tests/e2e` に修正し、全件通るようにした。

## Out of scope

終日イベントへの `[busy]`/`[free]` タグ付与（#53 の補足で言及）。既存の出力仕様変更を伴うため別タスクとした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PUYogSFgTPAAwdodXGW5g