### PR TITLE
fix: surface all-day availability and warn when --busy hides events (#55)

### DIFF
--- a/spec/commands.md
+++ b/spec/commands.md
@@ -58,7 +58,13 @@ gcal list --today --busy
 gcal list --days 7 --confirmed
 ```
 
-Quiet mode (`-q`): Compact one-line format: `MM/DD HH:MM-HH:MM Title`. Stderr messages suppressed.
+`--busy` caveat: Google Calendar marks all-day events as free by default, so
+`--busy` hides most of them and a fully booked day can look empty. Any all-day
+event it hides is reported on stderr with its date and title. See
+[output.md](./output.md#--busy-and-all-day-events).
+
+Quiet mode (`-q`): Compact one-line format: `MM/DD HH:MM-HH:MM Title`. Warnings
+still go to stderr, so stdout stays clean for piping.
 
 ### `gcal search`
 
@@ -101,7 +107,12 @@ Searching: 2026-01-25 to 2026-02-24
 Tip: Use --days <n> or --from/--to to change the search range.
 ```
 
-Quiet mode (`-q`): Same compact format as `list` (`MM/DD HH:MM-HH:MM Title`). Stderr messages suppressed.
+`--busy` hides all-day events for the same reason as `list`, and reports them on
+stderr in the same format.
+
+Quiet mode (`-q`): Same compact format as `list` (`MM/DD HH:MM-HH:MM Title`).
+Unlike `list`, `search` suppresses **all** stderr messages under `--quiet`,
+including the `--busy` notice.
 
 ### `gcal add`
 

--- a/spec/output.md
+++ b/spec/output.md
@@ -8,12 +8,12 @@ Human-readable format for terminal use.
 
 ```
 2026-01-24 (Fri)
-  [All Day]     Company Holiday (Main Calendar)
+  [All Day]     Company Holiday (Main Calendar) [busy]
   10:00-11:00   Team Meeting (Main Calendar) [busy]
   14:00-15:00   Focus Time (Work Calendar) [free]
 
 2026-01-25 (Sat)
-  [All Day]     Vacation (Main Calendar)
+  [All Day]     Vacation (Main Calendar) [busy]
 ```
 
 #### Multi-day Events
@@ -24,11 +24,11 @@ all-day events keep the plain `[All Day]` label.
 
 ```
 2026-12-05 (Sat)
-  [All Day 1/2]   Aコース (Main Calendar)
+  [All Day 1/2]   Aコース (Main Calendar) [free]
   10:00-11:00     Team Meeting (Main Calendar) [busy]
 
 2026-12-06 (Sun)
-  [All Day 2/2]   Aコース (Main Calendar)
+  [All Day 2/2]   Aコース (Main Calendar) [free]
 ```
 
 Notes:
@@ -43,6 +43,37 @@ Notes:
   does not appear on the following day.
 - The time column widens to fit the longest label in the output, so a listing
   without multi-day events keeps the 11-character `HH:MM-HH:MM` width.
+
+#### Availability Tags
+
+Every event row ends with `[busy]` or `[free]`, all-day events included.
+
+Google Calendar marks all-day events as **free** by default, so most of them
+show `[free]` even when the day is fully committed. The tag is what makes that
+visible — without it, `--busy` appears to drop events for no reason.
+
+#### `--busy` and All-day Events
+
+`--busy` keeps only `opaque` events, which removes most all-day events. Because
+that can make a fully booked day look empty, the hidden events are reported on
+**stderr** (stdout stays clean for piping):
+
+```
+Note: 3 all-day events are hidden by --busy (Google Calendar marks all-day events as free by default):
+  2026-09-05  日本看護研究学会第52回学術集会
+  2026-09-05  【宿泊】ホテルココ・グラン高崎（朝食付）
+  2026-09-05  Stay at ホテルココ・グラン高崎
+```
+
+Rules:
+
+- Only `--busy` triggers the notice. `--free` explicitly asks for open time, and
+  timed events dropped by `--busy` match what was requested, so neither is
+  reported.
+- At most 5 titles are listed; the rest are summarised as `... and N more`.
+- `gcal list` emits the notice in every mode including `--quiet` and `-f json`.
+  `gcal search` suppresses all stderr output under `--quiet`, so the notice is
+  omitted there.
 
 ### `gcal search` Text Output
 
@@ -60,7 +91,7 @@ annotated inline:
 ```
 Found 2 events matching "A":
 
-2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar)
+2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar) [free]
 2026-12-05 23:00-12/06 01:00      Night Shift (Main Calendar) [busy]
 ```
 

--- a/spec/tasks/040-all-day-free-busy.md
+++ b/spec/tasks/040-all-day-free-busy.md
@@ -1,0 +1,113 @@
+# Task: 終日イベントの free/busy を可視化し、--busy による非表示を通知
+
+## Purpose
+
+Google カレンダーは終日イベントを既定で `transparency: transparent`（予定なし）にするため、`gcal list --busy` が実際に埋まっている終日予定を全部落とす (#55)。#53 と同じ「埋まっている日が空きに見える」誤判定がフィルタ経路で起きる。
+
+Google の free/busy 定義自体は曲げず、**(A) 終日イベントにもタグを表示** し、**(B) `--busy` が隠した終日イベントを件名付きで stderr に通知** することで、誤判定を防ぐ。
+
+## Context
+
+- Issue: #55（#53 の関連）
+- Related files:
+  - `src/lib/output.ts` — `formatEventListText()`, `formatSearchResultText()`
+  - `src/lib/filter.ts` — `filterByTransparency()`, `applyFilters()`
+  - `src/commands/list.ts` — `handleList()`
+  - `src/commands/search.ts` — `handleSearch()`
+- Related specs: `spec/output.md`, `spec/commands.md`
+- Dependencies: 039-multi-day-event-display（同じ描画コードを触るため、そのブランチに積む）
+
+## Design Decisions
+
+### (A) 終日イベントへのタグ表示
+
+`formatEventListText()` / search 行は現在 `event.all_day` のとき `transparencyTag()` を呼ばない。これを撤廃し、終日・時刻指定を問わず `[busy]` / `[free]` を出す。
+
+```
+2026-09-05 (Sat)
+  [All Day 1/2]   日本看護研究学会第52回学術集会 (ncukondo@gmail.com) [free]
+  [All Day]       【宿泊】ホテルココ・グラン高崎（朝食付） (ncukondo@gmail.com) [free]
+```
+
+`--quiet` は機械処理向けの形式なので変更しない（元々どのイベントにもタグを出していない）。
+`gcal show` は既に `Availability: free/busy` を出しているため変更なし。
+
+### (B) 隠した終日イベントの通知
+
+`--busy` のときだけ通知する。`--free` が opaque な終日イベントを落とすケースは、
+「予定なし」を明示的に探しているので誤判定の危険がなく、通知しない。
+
+対象は **transparency フィルタが落とした終日イベント**のみ。時刻指定イベントが `--busy` で落ちるのは
+ユーザーの明示的な意図どおりなので通知しない（通知すると `--busy` のたびに大量のノイズになる）。
+status フィルタで落ちるイベント（cancelled / tentative）も対象外。
+
+`src/lib/filter.ts` に純粋関数を追加する:
+
+```ts
+export function findHiddenAllDayEvents(
+  events: CalendarEvent[],
+  options: FilterOptions,
+): CalendarEvent[];
+```
+
+出力（stderr、最大5件まで列挙し残りは件数のみ）:
+
+```
+Note: 3 all-day events are hidden by --busy (Google Calendar marks all-day events as free by default):
+  2026-09-05  日本看護研究学会第52回学術集会@フォルダー作成済
+  2026-09-05  【宿泊】ホテルココ・グラン高崎（朝食付）
+  2026-09-05  Stay at ホテルココ・グラン高崎
+```
+
+6件以上のときは末尾に `  ... and N more` を付ける（無言で切り捨てない）。
+
+### `--quiet` との関係
+
+各コマンドの既存の慣習に合わせる。`list` は `--quiet` でも stderr の警告を出す
+（`--from not specified` の警告と同じ扱い）。`search` は `handleSearch()` が `quiet` のとき
+`writeErr` を握り潰す実装（`search.ts:39`）なので、そちらに従い通知しない。
+
+### Out of Scope
+
+`gcal add` の終日イベントが `transparency: opaque` 固定で Google UI（`transparent`）と逆になる件
+（`src/commands/add.ts:80`）。破壊的変更になるため #55 の補足に記載して別途検討する。
+
+## Implementation Steps
+
+- [x] `src/lib/filter.test.ts`: `findHiddenAllDayEvents()` の失敗テストを書く（--busy で終日 transparent のみ返す / 時刻指定は返さない / --free と未指定では空 / cancelled・tentative は除外）
+- [x] `src/lib/filter.ts`: `findHiddenAllDayEvents()` を実装
+- [x] `src/lib/output.test.ts`: 終日イベントにタグが出ることの失敗テストを追加、既存の「タグを出さない」テストを反転
+- [x] `src/lib/output.ts`: `formatEventListText()` / `formatSearchResultText()` の all_day 分岐を撤廃
+- [x] `src/commands/list.test.ts` / `src/commands/list.ts`: `--busy` 時の stderr 通知（件数・件名・5件超の省略）
+- [x] `src/commands/search.test.ts` / `src/commands/search.ts`: 同上（`--quiet` 時は出さない）
+- [x] `spec/output.md`: 終日イベントのタグ表示を反映
+- [x] `spec/commands.md`: `--busy` の注意書きを追加
+- [x] `tests/e2e/multi-day-events.test.ts` or 新規: 終日イベントが `--busy` で隠れたとき stderr に件名が出ること
+- [x] `bun run test` pass
+- [x] `bun run lint` / `format:check` / `typecheck` pass
+
+## E2E Test
+
+`tests/e2e/all-day-free-busy.test.ts` として実装（全体 37/37 pass）。
+
+- [x] 終日イベント（transparent）を作成し、`gcal list --busy` で stderr に件数と件名が出ること
+- [x] `gcal list` の通常出力で終日イベントに `[free]` が付くこと
+- [x] `--free` / フィルタなしでは通知が出ないこと
+- [x] `-f json` の stdout が parse 可能なまま通知が stderr に出ること
+
+## Acceptance Criteria
+
+- [x] 終日イベント行に `[busy]` / `[free]` が表示される
+- [x] `--busy` で終日イベントが隠れたとき、件数と件名が stderr に出る
+- [x] 6件以上のときは省略件数が明示される
+- [x] 時刻指定イベントが `--busy` で落ちても通知されない
+- [x] `--free` では通知されない
+- [x] `search --quiet` では通知されない
+- [x] JSON 出力は変更されない
+- [x] 既存テストが pass する
+
+## Notes
+
+- `spec/commands.md` の「Quiet mode: Stderr messages suppressed」は `list` の実装と食い違っていた
+  （`list --quiet` は `--from not specified` 警告を stderr に出す）。実装に合わせて spec を修正した。
+  `search --quiet` は `search.ts:39` で stderr を握り潰す実装のままとし、両者の差を spec に明記した。

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -743,3 +743,95 @@ describe("createListCommand", () => {
     expect(opts.calendar).toEqual(["cal1", "cal2"]);
   });
 });
+
+describe("handleList --busy all-day warning", () => {
+  const conference = makeEvent({
+    id: "conf",
+    all_day: true,
+    start: "2026-09-05",
+    end: "2026-09-07",
+    title: "日本看護研究学会第52回学術集会",
+    transparency: "transparent",
+  });
+  const freeTimed = makeEvent({
+    id: "confcall",
+    start: "2026-09-05T08:00:00+09:00",
+    end: "2026-09-05T09:00:00+09:00",
+    title: "外来カンファ",
+    transparency: "transparent",
+  });
+
+  function makeSingleCalendarDeps(events: CalendarEvent[]) {
+    const writeErr = vi.fn();
+    const deps = makeDeps({
+      listEvents: vi.fn().mockResolvedValue(events),
+      loadConfig: vi
+        .fn()
+        .mockReturnValue(
+          makeConfig({ calendars: [{ id: "primary", name: "Main Calendar", enabled: true }] }),
+        ),
+      writeErr,
+    });
+    return { deps, writeErr };
+  }
+
+  const range = { from: "2026-09-05", to: "2026-09-06", timezone: "Asia/Tokyo" } as const;
+
+  it("warns with count and title when --busy hides an all-day event", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference]);
+
+    await handleList({ ...range, busy: true, format: "text", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).toContain("1 all-day event is hidden by --busy");
+    expect(warning).toContain("日本看護研究学会第52回学術集会");
+  });
+
+  it("does not mention timed events dropped by --busy", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference, freeTimed]);
+
+    await handleList({ ...range, busy: true, format: "text", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).not.toContain("外来カンファ");
+  });
+
+  it("does not warn without --busy", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference]);
+
+    await handleList({ ...range, format: "text", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).not.toContain("hidden by --busy");
+  });
+
+  it("does not warn for --free", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference]);
+
+    await handleList({ ...range, free: true, format: "text", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).not.toContain("hidden by --busy");
+  });
+
+  it("still warns in --quiet mode since the notice goes to stderr", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference]);
+
+    await handleList({ ...range, busy: true, format: "text", quiet: true }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).toContain("hidden by --busy");
+  });
+
+  it("still warns in JSON mode without touching stdout", async () => {
+    const { deps, writeErr } = makeSingleCalendarDeps([conference]);
+    const write = vi.fn();
+    deps.write = write;
+
+    await handleList({ ...range, busy: true, format: "json", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).toContain("hidden by --busy");
+    expect(() => JSON.parse(write.mock.calls[0]![0] as string)).not.toThrow();
+  });
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,8 +4,13 @@ import { ExitCode } from "../types/index.ts";
 import type { ListEventsOptions } from "../lib/api.ts";
 import { resolveTimezone, formatDateTimeInZone, parseDateTimeInZone } from "../lib/timezone.ts";
 import { selectCalendars } from "../lib/config.ts";
-import { applyFilters } from "../lib/filter.ts";
-import { formatEventListText, formatJsonSuccess, formatQuietText } from "../lib/output.ts";
+import { applyFilters, findHiddenAllDayEvents } from "../lib/filter.ts";
+import {
+  formatEventListText,
+  formatHiddenAllDayWarning,
+  formatJsonSuccess,
+  formatQuietText,
+} from "../lib/output.ts";
 import type { DayRange } from "../lib/event-days.ts";
 import { addDaysToDateString } from "../lib/date-utils.ts";
 import { collect } from "./shared.ts";
@@ -179,6 +184,12 @@ export async function handleList(
   if (options.confirmed) filterOpts.confirmed = true;
   if (options.includeTentative) filterOpts.includeTentative = true;
   const filtered = applyFilters(allEvents, filterOpts);
+
+  // A day booked solid with all-day events would otherwise come back empty.
+  const hiddenAllDay = findHiddenAllDayEvents(allEvents, filterOpts);
+  if (hiddenAllDay.length > 0) {
+    writeErr(formatHiddenAllDayWarning(hiddenAllDay));
+  }
 
   // Output
   if (options.format === "json") {

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -458,6 +458,63 @@ describe("search command", () => {
     });
   });
 
+  describe("--busy all-day warning", () => {
+    const conference = makeEvent({
+      id: "conf",
+      all_day: true,
+      start: "2026-09-05",
+      end: "2026-09-07",
+      title: "日本看護研究学会第52回学術集会",
+      transparency: "transparent",
+    });
+    const freeTimed = makeEvent({
+      id: "confcall",
+      title: "外来カンファ",
+      transparency: "transparent",
+    });
+
+    it("warns with count and title when --busy hides an all-day event", async () => {
+      const { errOutput } = await runSearch(makeMockApi([conference]), {
+        query: "学会",
+        busy: true,
+      });
+      const warning = errOutput.join("\n");
+      expect(warning).toContain("1 all-day event is hidden by --busy");
+      expect(warning).toContain("日本看護研究学会第52回学術集会");
+    });
+
+    it("does not mention timed events dropped by --busy", async () => {
+      const { errOutput } = await runSearch(makeMockApi([conference, freeTimed]), {
+        query: "カンファ",
+        busy: true,
+      });
+      expect(errOutput.join("\n")).not.toContain("外来カンファ");
+    });
+
+    it("does not warn without --busy", async () => {
+      const { errOutput } = await runSearch(makeMockApi([conference]), { query: "学会" });
+      expect(errOutput.join("\n")).not.toContain("hidden by --busy");
+    });
+
+    it("does not warn for --free", async () => {
+      const { errOutput } = await runSearch(makeMockApi([conference]), {
+        query: "学会",
+        free: true,
+      });
+      expect(errOutput.join("\n")).not.toContain("hidden by --busy");
+    });
+
+    // handleSearch silences stderr entirely in quiet mode.
+    it("does not warn in --quiet mode", async () => {
+      const { errOutput } = await runSearch(makeMockApi([conference]), {
+        query: "学会",
+        busy: true,
+        quiet: true,
+      });
+      expect(errOutput).toEqual([]);
+    });
+  });
+
   describe("--days parser", () => {
     it("parses --days with radix 10", () => {
       const cmd = createSearchCommand();

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,9 +1,14 @@
 import { Command } from "commander";
 import type { GoogleCalendarApi } from "../lib/api.ts";
 import { listEvents } from "../lib/api.ts";
-import { applyFilters } from "../lib/filter.ts";
+import { applyFilters, findHiddenAllDayEvents } from "../lib/filter.ts";
 import type { FilterOptions, TransparencyOption } from "../lib/filter.ts";
-import { formatJsonSuccess, formatSearchResultText, formatQuietText } from "../lib/output.ts";
+import {
+  formatHiddenAllDayWarning,
+  formatJsonSuccess,
+  formatSearchResultText,
+  formatQuietText,
+} from "../lib/output.ts";
 import { collect } from "./shared.ts";
 import { formatDateTimeInZone, parseDateTimeInZone } from "../lib/timezone.ts";
 import { addDays } from "date-fns";
@@ -91,6 +96,12 @@ export async function handleSearch(opts: SearchHandlerOptions): Promise<CommandR
   if (opts.confirmed !== undefined) filterOpts.confirmed = opts.confirmed;
   if (opts.includeTentative !== undefined) filterOpts.includeTentative = opts.includeTentative;
   const filtered = applyFilters(allEvents, filterOpts);
+
+  // Google Calendar marks all-day events as free, so --busy silently drops them.
+  const hiddenAllDay = findHiddenAllDayEvents(allEvents, filterOpts);
+  if (hiddenAllDay.length > 0) {
+    writeErr(formatHiddenAllDayWarning(hiddenAllDay));
+  }
 
   if (format === "json") {
     write(

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { CalendarEvent } from "../types/index.ts";
-import { applyFilters, filterByStatus, filterByTransparency } from "./filter.ts";
+import {
+  applyFilters,
+  filterByStatus,
+  filterByTransparency,
+  findHiddenAllDayEvents,
+} from "./filter.ts";
 
 function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   return {
@@ -161,5 +166,96 @@ describe("applyFilters", () => {
   it("returns empty array for empty input", () => {
     const result = applyFilters([], { transparency: "busy" });
     expect(result).toEqual([]);
+  });
+});
+
+describe("findHiddenAllDayEvents", () => {
+  const freeAllDay = makeEvent({
+    id: "ad1",
+    title: "学会",
+    all_day: true,
+    start: "2026-09-05",
+    end: "2026-09-07",
+    transparency: "transparent",
+  });
+  const busyAllDay = makeEvent({
+    id: "ad2",
+    title: "Blocked Day",
+    all_day: true,
+    start: "2026-09-08",
+    end: "2026-09-09",
+    transparency: "opaque",
+  });
+  const freeTimed = makeEvent({ id: "t1", title: "外来カンファ", transparency: "transparent" });
+  const busyTimed = makeEvent({ id: "t2", title: "登壇", transparency: "opaque" });
+
+  const events = [freeAllDay, busyAllDay, freeTimed, busyTimed];
+
+  it("returns all-day events dropped by --busy", () => {
+    expect(findHiddenAllDayEvents(events, { transparency: "busy" })).toEqual([freeAllDay]);
+  });
+
+  it("does not report timed events dropped by --busy", () => {
+    const result = findHiddenAllDayEvents(events, { transparency: "busy" });
+    expect(result).not.toContain(freeTimed);
+  });
+
+  it("does not report all-day events that survive --busy", () => {
+    const result = findHiddenAllDayEvents(events, { transparency: "busy" });
+    expect(result).not.toContain(busyAllDay);
+  });
+
+  it("returns nothing for --free", () => {
+    expect(findHiddenAllDayEvents(events, { transparency: "free" })).toEqual([]);
+  });
+
+  it("returns nothing when no transparency filter is active", () => {
+    expect(findHiddenAllDayEvents(events, {})).toEqual([]);
+  });
+
+  it("excludes events that the status filter would drop anyway", () => {
+    const cancelledAllDay = makeEvent({
+      id: "ad3",
+      title: "Cancelled Trip",
+      all_day: true,
+      start: "2026-09-10",
+      end: "2026-09-11",
+      transparency: "transparent",
+      status: "cancelled",
+    });
+    const tentativeAllDay = makeEvent({
+      id: "ad4",
+      title: "Maybe Trip",
+      all_day: true,
+      start: "2026-09-12",
+      end: "2026-09-13",
+      transparency: "transparent",
+      status: "tentative",
+    });
+    const result = findHiddenAllDayEvents([freeAllDay, cancelledAllDay, tentativeAllDay], {
+      transparency: "busy",
+    });
+    expect(result).toEqual([freeAllDay]);
+  });
+
+  it("includes tentative all-day events when --include-tentative is set", () => {
+    const tentativeAllDay = makeEvent({
+      id: "ad4",
+      title: "Maybe Trip",
+      all_day: true,
+      start: "2026-09-12",
+      end: "2026-09-13",
+      transparency: "transparent",
+      status: "tentative",
+    });
+    const result = findHiddenAllDayEvents([freeAllDay, tentativeAllDay], {
+      transparency: "busy",
+      includeTentative: true,
+    });
+    expect(result).toEqual([freeAllDay, tentativeAllDay]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(findHiddenAllDayEvents([], { transparency: "busy" })).toEqual([]);
   });
 });

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -47,3 +47,24 @@ export function applyFilters(events: CalendarEvent[], options: FilterOptions): C
   const afterTransparency = filterByTransparency(events, options.transparency);
   return filterByStatus(afterTransparency, options);
 }
+
+/**
+ * All-day events that `--busy` removes from the result.
+ *
+ * Google Calendar marks all-day events as `transparent` by default, so `--busy`
+ * silently drops real commitments the user never chose to mark as free. Callers
+ * surface these so a booked day cannot look empty.
+ *
+ * Only `--busy` is reported: `--free` explicitly asks for open time, and timed
+ * events dropped by `--busy` match what the user asked for.
+ */
+export function findHiddenAllDayEvents(
+  events: CalendarEvent[],
+  options: FilterOptions,
+): CalendarEvent[] {
+  if (options.transparency !== "busy") return [];
+
+  return filterByStatus(events, options).filter(
+    (event) => event.all_day && event.transparency === "transparent",
+  );
+}

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -8,6 +8,7 @@ import {
   formatCalendarListText,
   formatEventDetailText,
   formatQuietText,
+  formatHiddenAllDayWarning,
   errorCodeToExitCode,
 } from "./output.ts";
 
@@ -149,7 +150,7 @@ describe("formatEventListText", () => {
     expect(result).toContain("2026-12-31 (Thu)");
   });
 
-  it("does not show transparency tag for all-day events", () => {
+  it("shows [busy] tag for opaque all-day events", () => {
     const events = [
       makeEvent({
         all_day: true,
@@ -160,8 +161,24 @@ describe("formatEventListText", () => {
       }),
     ];
     const result = formatEventListText(events);
-    expect(result).not.toContain("[busy]");
-    expect(result).not.toContain("[free]");
+    expect(result).toContain("[busy]");
+  });
+
+  // Google Calendar marks all-day events as free by default, so the tag is the
+  // only on-screen clue that --busy would hide them.
+  it("shows [free] tag for transparent all-day events", () => {
+    const events = [
+      makeEvent({
+        all_day: true,
+        start: "2026-09-05",
+        end: "2026-09-07",
+        title: "学会",
+        transparency: "transparent",
+      }),
+    ];
+    const result = formatEventListText(events);
+    expect(result).toContain("  [All Day 1/2]   学会 (Main Calendar) [free]");
+    expect(result).toContain("  [All Day 2/2]   学会 (Main Calendar) [free]");
   });
 
   it("returns empty string for empty event list", () => {
@@ -205,12 +222,12 @@ describe("formatEventListText", () => {
     const result = formatEventListText(events);
     const expected = [
       "2026-01-24 (Sat)",
-      "  [All Day]     Company Holiday (Main Calendar)",
+      "  [All Day]     Company Holiday (Main Calendar) [busy]",
       "  10:00-11:00   Team Meeting (Main Calendar) [busy]",
       "  14:00-15:00   Focus Time (Work Calendar) [free]",
       "",
       "2026-01-25 (Sun)",
-      "  [All Day]     Vacation (Main Calendar)",
+      "  [All Day]     Vacation (Main Calendar) [busy]",
     ].join("\n");
     expect(result).toBe(expected);
   });
@@ -228,10 +245,10 @@ describe("formatEventListText", () => {
       const result = formatEventListText(events);
       const expected = [
         "2026-12-05 (Sat)",
-        "  [All Day 1/2]   Aコース (Main Calendar)",
+        "  [All Day 1/2]   Aコース (Main Calendar) [busy]",
         "",
         "2026-12-06 (Sun)",
-        "  [All Day 2/2]   Aコース (Main Calendar)",
+        "  [All Day 2/2]   Aコース (Main Calendar) [busy]",
       ].join("\n");
       expect(result).toBe(expected);
     });
@@ -256,11 +273,11 @@ describe("formatEventListText", () => {
       const result = formatEventListText(events);
       const expected = [
         "2026-12-05 (Sat)",
-        "  [All Day 1/2]   Aコース (Main Calendar)",
+        "  [All Day 1/2]   Aコース (Main Calendar) [busy]",
         "  10:00-11:00     Team Meeting (Main Calendar) [busy]",
         "",
         "2026-12-06 (Sun)",
-        "  [All Day 2/2]   Aコース (Main Calendar)",
+        "  [All Day 2/2]   Aコース (Main Calendar) [busy]",
       ].join("\n");
       expect(result).toBe(expected);
     });
@@ -296,7 +313,7 @@ describe("formatEventListText", () => {
       const result = formatEventListText(events);
       const dayHeaders = result.split("\n").filter((line) => line.startsWith("2026-"));
       expect(dayHeaders).toEqual(["2026-12-05 (Sat)", "2026-12-06 (Sun)", "2026-12-07 (Mon)"]);
-      expect(result).toContain("  [All Day 2/3]   Aコース (Main Calendar)");
+      expect(result).toContain("  [All Day 2/3]   Aコース (Main Calendar) [busy]");
       expect(result).toContain("  09:00-10:00     Team Meeting (Main Calendar) [busy]");
     });
   });
@@ -307,7 +324,10 @@ describe("formatEventListText", () => {
         makeEvent({ all_day: true, start: "2026-12-05", end: "2026-12-08", title: "Aコース" }),
       ];
       const result = formatEventListText(events, { from: "2026-12-06", to: "2026-12-06" });
-      const expected = ["2026-12-06 (Sun)", "  [All Day 2/3]   Aコース (Main Calendar)"].join("\n");
+      const expected = [
+        "2026-12-06 (Sun)",
+        "  [All Day 2/3]   Aコース (Main Calendar) [busy]",
+      ].join("\n");
       expect(result).toBe(expected);
     });
 
@@ -405,7 +425,7 @@ describe("formatSearchResultText", () => {
       }),
     ];
     const result = formatSearchResultText("holiday", events);
-    expect(result).toContain("2026-01-24 [All Day]    Company Holiday (Main Calendar)");
+    expect(result).toContain("2026-01-24 [All Day]    Company Holiday (Main Calendar) [busy]");
   });
 
   it("annotates the period on multi-day all-day events", () => {
@@ -419,7 +439,7 @@ describe("formatSearchResultText", () => {
       }),
     ];
     const result = formatSearchResultText("A", events);
-    expect(result).toContain("2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar)");
+    expect(result).toContain("2026-12-05 [All Day 12/05-12/06]  Aコース (Main Calendar) [busy]");
   });
 
   it("annotates the end date on timed events crossing midnight", () => {
@@ -723,5 +743,47 @@ describe("errorCodeToExitCode", () => {
 
   it("maps CONFIG_ERROR to exit code 1", () => {
     expect(errorCodeToExitCode("CONFIG_ERROR")).toBe(1);
+  });
+});
+
+describe("formatHiddenAllDayWarning", () => {
+  function allDay(title: string, start: string): CalendarEvent {
+    return makeEvent({ all_day: true, start, end: start, title, transparency: "transparent" });
+  }
+
+  it("lists the count and the title of each hidden event", () => {
+    const result = formatHiddenAllDayWarning([
+      allDay("日本看護研究学会第52回学術集会", "2026-09-05"),
+      allDay("【宿泊】ホテルココ・グラン高崎", "2026-09-05"),
+    ]);
+    expect(result).toBe(
+      [
+        "Note: 2 all-day events are hidden by --busy (Google Calendar marks all-day events as free by default):",
+        "  2026-09-05  日本看護研究学会第52回学術集会",
+        "  2026-09-05  【宿泊】ホテルココ・グラン高崎",
+      ].join("\n"),
+    );
+  });
+
+  it("uses singular wording for a single event", () => {
+    const result = formatHiddenAllDayWarning([allDay("学会", "2026-09-05")]);
+    expect(result).toContain("1 all-day event is hidden by --busy");
+  });
+
+  it("caps the list at 5 entries and reports the remainder", () => {
+    const events = Array.from({ length: 8 }, (_, i) =>
+      allDay(`Event ${i + 1}`, `2026-09-0${i + 1}`),
+    );
+    const result = formatHiddenAllDayWarning(events);
+    const lines = result.split("\n");
+    expect(lines[0]).toContain("8 all-day events are hidden");
+    expect(lines).toHaveLength(7);
+    expect(lines[1]).toContain("Event 1");
+    expect(lines[5]).toContain("Event 5");
+    expect(lines[6]).toBe("  ... and 3 more");
+  });
+
+  it("returns an empty string when nothing is hidden", () => {
+    expect(formatHiddenAllDayWarning([])).toBe("");
   });
 });

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -82,8 +82,7 @@ export function formatEventListText(events: CalendarEvent[], range?: DayRange): 
     const day = days[i]!;
     const { event } = day;
     const time = labels[i]!.padEnd(width);
-    const tag = event.all_day ? "" : ` ${transparencyTag(event)}`;
-    const line = `  ${time}   ${event.title} (${event.calendar_name})${tag}`;
+    const line = `  ${time}   ${event.title} (${event.calendar_name}) ${transparencyTag(event)}`;
 
     const group = groups.get(day.date);
     if (group) {
@@ -118,9 +117,36 @@ export function formatSearchResultText(query: string, events: CalendarEvent[]): 
     const event = events[i]!;
     const date = event.start.slice(0, 10);
     const time = labels[i]!.padEnd(width);
-    const tag = event.all_day ? "" : ` ${transparencyTag(event)}`;
-    lines.push(`${date} ${time}  ${event.title} (${event.calendar_name})${tag}`);
+    lines.push(
+      `${date} ${time}  ${event.title} (${event.calendar_name}) ${transparencyTag(event)}`,
+    );
   }
+  return lines.join("\n");
+}
+
+const HIDDEN_EVENT_LIST_MAX = 5;
+
+/**
+ * Warning for all-day events that `--busy` removed from the result.
+ *
+ * Google Calendar marks all-day events as free by default, so a fully booked
+ * day can otherwise come back empty. Titles are listed so the user can judge
+ * whether the day is really open.
+ */
+export function formatHiddenAllDayWarning(events: CalendarEvent[]): string {
+  if (events.length === 0) return "";
+
+  const verb = events.length === 1 ? "event is" : "events are";
+  const lines = [
+    `Note: ${events.length} all-day ${verb} hidden by --busy ` +
+      `(Google Calendar marks all-day events as free by default):`,
+  ];
+  for (const event of events.slice(0, HIDDEN_EVENT_LIST_MAX)) {
+    lines.push(`  ${event.start.slice(0, 10)}  ${event.title}`);
+  }
+  const remaining = events.length - HIDDEN_EVENT_LIST_MAX;
+  if (remaining > 0) lines.push(`  ... and ${remaining} more`);
+
   return lines.join("\n");
 }
 

--- a/tests/e2e/all-day-free-busy.test.ts
+++ b/tests/e2e/all-day-free-busy.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterAll } from "vitest";
+import {
+  runCli,
+  runCliJson,
+  testEventTitle,
+  todayDate,
+  TestCleanup,
+  hasCredentials,
+  retryUntil,
+} from "./helpers.ts";
+
+const creds = hasCredentials();
+
+/** YYYY-MM-DD `days` after today, in local time. */
+function dateOffset(days: number): string {
+  const [y, m, d] = todayDate().split("-").map(Number);
+  const date = new Date(y!, m! - 1, d! + days);
+  const yy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+const day = dateOffset(50);
+
+describe.runIf(creds)("E2E: all-day free/busy", () => {
+  const cleanup = new TestCleanup();
+
+  afterAll(async () => {
+    await cleanup.deleteAll();
+  });
+
+  const freeTitle = testEventTitle("AllDayFree");
+
+  it("add creates a free all-day event", async () => {
+    const { json, result } = await runCliJson(
+      "add",
+      "--title",
+      freeTitle,
+      "--start",
+      day,
+      "--free",
+    );
+
+    expect(result.exitCode).toBe(0);
+    const data = json as {
+      data: { event: { id: string; all_day: boolean; transparency: string } };
+    };
+    expect(data.data.event.all_day).toBe(true);
+    expect(data.data.event.transparency).toBe("transparent");
+    cleanup.track(data.data.event.id);
+  });
+
+  it("list tags the all-day event as [free]", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day, "--to", day);
+      expect(result.exitCode).toBe(0);
+      const line = result.stdout.split("\n").find((l) => l.includes(freeTitle));
+      expect(line).toBeDefined();
+      expect(line).toContain("[All Day]");
+      expect(line).toContain("[free]");
+    });
+  });
+
+  it("list --busy hides it from stdout but names it on stderr", async () => {
+    await retryUntil(async () => {
+      const result = await runCli("list", "--from", day, "--to", day, "--busy");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain(freeTitle);
+      expect(result.stderr).toContain("hidden by --busy");
+      expect(result.stderr).toContain(freeTitle);
+      expect(result.stderr).toContain(day);
+    });
+  });
+
+  it("list --free does not emit the notice", async () => {
+    const result = await runCli("list", "--from", day, "--to", day, "--free");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(freeTitle);
+    expect(result.stderr).not.toContain("hidden by --busy");
+  });
+
+  it("list without a transparency filter does not emit the notice", async () => {
+    const result = await runCli("list", "--from", day, "--to", day);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("hidden by --busy");
+  });
+
+  it("list --busy -f json keeps stdout parseable", async () => {
+    const result = await runCli("-f", "json", "list", "--from", day, "--to", day, "--busy");
+    expect(result.exitCode).toBe(0);
+    expect(() => JSON.parse(result.stdout)).not.toThrow();
+    expect(result.stderr).toContain("hidden by --busy");
+  });
+});


### PR DESCRIPTION
Fixes #55 — **stacked on #54**（base は `fix/53-multi-day-event-display`）。#54 がマージされれば GitHub が自動で base を `main` に付け替えます。

## 問題

Google カレンダーは終日イベントを既定で `transparency: transparent`（予定なし）にする。そのため `gcal list --busy` が実際に埋まっている終日予定を全部落とし、**丸一日埋まっている日が `No events found.` になる**。しかも終日イベント行には `[busy]`/`[free]` が出ていなかったため、なぜ消えたのか画面から分からなかった。

#53 と同じ「埋まっている日が空きに見える」誤判定が、グループ化ではなくフィルタ経路で起きていた。

## 変更

**(A) 終日イベントにも availability タグを表示** — `formatEventListText()` / search 行の `all_day` 分岐を撤廃。Google の既定が free であることが画面で見える。

**(B) `--busy` が隠した終日イベントを stderr に通知** — `findHiddenAllDayEvents()`（`src/lib/filter.ts`）が transparency フィルタの落としたぶんを返し、`list` / `search` が件数と**件名**を出す。stdout はパイプ用にクリーンなまま。

- 通知は `--busy` のときだけ。`--free` は「予定なし」を明示的に探しているので誤判定の危険がなく、時刻指定イベントが `--busy` で落ちるのはユーザーの意図どおりなので、どちらも通知しない。
- 最大5件まで列挙し、残りは `... and N more`（無言で切り捨てない）。
- cancelled / tentative は status フィルタで落ちるぶんなので対象外。

Google の free/busy 定義自体は変えていない（`--busy` に終日イベントを常に含める、といったことはしない）。JSON 出力も不変。

## 実カレンダーでの Before / After

```console
# Before
$ gcal list --from 2026-09-05 --to 2026-09-05
2026-09-05 (Sat)
  [All Day 1/2]   日本看護研究学会第52回学術集会 (ncukondo@gmail.com)
  ...
$ gcal list --from 2026-09-05 --to 2026-09-05 --busy
No events found.                                    # ← 何も説明がない
```

```console
# After
$ gcal list --from 2026-09-05 --to 2026-09-05
2026-09-05 (Sat)
  [All Day 1/2]   日本看護研究学会第52回学術集会@フォルダー作成済 (ncukondo@gmail.com) [free]
  [All Day]       【宿泊】ホテルココ・グラン高崎（朝食付） (ncukondo@gmail.com) [free]
  [All Day 1/2]   Stay at ホテルココ・グラン高崎 (ncukondo@gmail.com) [free]

$ gcal list --from 2026-09-05 --to 2026-09-05 --busy
No events found.
# stderr:
Note: 3 all-day events are hidden by --busy (Google Calendar marks all-day events as free by default):
  2026-09-05  日本看護研究学会第52回学術集会@フォルダー作成済
  2026-09-05  【宿泊】ホテルココ・グラン高崎（朝食付）
  2026-09-05  Stay at ホテルココ・グラン高崎
```

## テスト

TDD (Red → Green)。lint・format:check・typecheck も pass。

| suite | 件数 |
|---|---|
| unit | 701 |
| integration | 72 |
| **e2e（実 API）** | **37** |

- `src/lib/filter.test.ts` — `findHiddenAllDayEvents()` 8件（--busy で終日 transparent のみ / 時刻指定は返さない / --free・未指定では空 / cancelled 除外 / --include-tentative）
- `src/lib/output.test.ts` — 終日イベントの `[busy]`/`[free]` 表示、警告文の単複・5件上限・`... and N more`
- `src/commands/list.test.ts` / `search.test.ts` — 通知の有無（--busy / --free / なし / --quiet / -f json）
- `tests/e2e/all-day-free-busy.test.ts`（新規 6件） — 実カレンダーに free な終日イベントを作成し、`[free]` タグ・`--busy` の stderr 通知・`--free` で通知が出ないこと・`-f json` の stdout が parse 可能なままであることを検証

## 付随修正: spec の誤り

`spec/commands.md` は `list` の quiet mode を「Stderr messages suppressed」と書いていたが、実装は元から stderr に警告を出していた（`--from not specified` 警告で確認）。本 PR の通知もこれに依存するため、実装に合わせて spec を修正。`search --quiet` は `search.ts:39` で stderr を握り潰す実装のままとし、両コマンドの差を spec に明記した。

## Out of scope

`gcal add` の終日イベントが `transparency: opaque` 固定（`src/commands/add.ts:80`）で、Google UI が作る終日イベント（`transparent`）と逆になる件。破壊的変更になるため #55 の補足に記載して別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PUYogSFgTPAAwdodXGW5g