### PR TITLE
fix: distinguish 403 permission errors from authentication errors

### DIFF
--- a/spec/output.md
+++ b/spec/output.md
@@ -235,6 +235,7 @@ Timezone: Asia/Tokyo
 | `NOT_FOUND` | Event or calendar not found |
 | `INVALID_ARGS` | Invalid command arguments |
 | `API_ERROR` | Google API error |
+| `FORBIDDEN` | Permission denied (read-only calendar, non-organizer); re-authenticating does not help |
 | `CONFIG_ERROR` | Configuration file error |
 
 ## Data Structures

--- a/spec/overview.md
+++ b/spec/overview.md
@@ -43,6 +43,9 @@ Only calendars containing "main" in their name are targeted by default.
 | 2 | Authentication error |
 | 3 | Argument error |
 
+Exit code 2 means re-authenticating can fix the problem. A permission error
+(`FORBIDDEN`) exits 1 instead, because `gcal auth` does not grant access.
+
 ## Related Specs
 
 - [commands.md](./commands.md) - Command specifications

--- a/spec/tasks/044-forbidden-vs-auth.md
+++ b/spec/tasks/044-forbidden-vs-auth.md
@@ -108,9 +108,27 @@ e.response.data.error.errors   同じ配列
 
 API の原文を保った上で、対処を添える。原因を断定しないこと（042 の 400 ヒントと同じ理由）。
 
+**当初は `reason` によらず単一の文言
+（`You may not have permission to change this event; only its organizer can.`）を
+付ける方針だったが、実装後のレビューで撤回した。** 唯一実 API で確認できている
+`requiredAccessLevel`（読み取り専用カレンダーへの `events.insert`）で
+
 ```
-Error: <API の原文> You may not have permission to change this event; only its organizer can.
+You need to have writer access to this calendar. You may not have permission to change this event; only its organizer can.
 ```
+
+となり、イベントも主催者も関係しない場面で原因を断定した上に、API 自身の正しい診断
+（「ここに write 権限を取れ」）から誤った出口（「主催者に頼め」）へ誘導していた。
+`mapApiError()` は Google Tasks とも共用のため、タスク側では意味を成さない。
+本節の「原因を断定しないこと」に自ら反していた。
+
+`reason` ごとに文言を持ち、**振り分け対象の `reason` はその表から導く**（二重管理を避ける）。
+再認証では直らないという情報は、どの文言にも必ず残す。
+
+| reason | 文言（API の原文に続けて付ける） |
+|---|---|
+| `requiredAccessLevel` | `Re-authenticating will not help; you need write access here.` |
+| `forbiddenForNonOrganizer` | `Re-authenticating will not help; only the organizer can change this event.` |
 
 ### `isAuthRequiredError()` の扱い
 

--- a/spec/tasks/044-forbidden-vs-auth.md
+++ b/spec/tasks/044-forbidden-vs-auth.md
@@ -129,18 +129,19 @@ Error: <API の原文> You may not have permission to change this event; only it
 - [x] **先に事実確認**: 実 API が 403 で返す本文と `reason` を確認する
       → Design Decisions の「確認済み」節を参照。`e.errors[0].reason` から読め、
       読み取り専用カレンダーは `requiredAccessLevel` を返す
-- [ ] `src/lib/api-utils.ts`: `isGoogleApiError()` を `reason` を読めるよう拡張（型と実装）
-- [ ] `src/types/index.ts`: `ErrorCode` に `FORBIDDEN` を追加
-- [ ] `src/lib/output.ts`: `ERROR_CODE_EXIT_MAP` に `FORBIDDEN: ExitCode.GENERAL` を追加
-- [ ] `src/cli.ts`: `getErrorCode()` の `validCodes` に `FORBIDDEN` を追加
-- [ ] `src/lib/api-utils.test.ts` / `api-utils.ts`: 403 の振り分け
+- [x] `src/lib/api-utils.ts`: `isGoogleApiError()` を `reason` を読めるよう拡張（型と実装）
+- [x] `src/types/index.ts`: `ErrorCode` に `FORBIDDEN` を追加
+- [x] `src/lib/output.ts`: `ERROR_CODE_EXIT_MAP` に `FORBIDDEN: ExitCode.GENERAL` を追加
+- [x] `src/cli.ts`: `getErrorCode()` の `validCodes` に `FORBIDDEN` を追加
+- [x] `src/lib/api-utils.test.ts` / `api-utils.ts`: 403 の振り分け
       （権限不足 → `FORBIDDEN` / スコープ不足 → `AUTH_REQUIRED` / `reason` 不明 → `AUTH_REQUIRED`）
-- [ ] `src/lib/api.ts`: `isAuthRequiredError()` が `FORBIDDEN` を含まないことをテストで固定
-- [ ] `src/commands/init.test.ts`: `FORBIDDEN` では自動再認証が起動しないこと
-- [ ] `src/lib/tasks-api.test.ts`: Tasks 側も同じ振り分けになること（`mapApiError()` 共用の確認）
-- [ ] `spec/output.md`: Error Codes 表に `FORBIDDEN` を追加
-- [ ] `spec/overview.md`: 必要なら Exit Codes の説明を補足
-- [ ] `bun run test:all` / `lint` / `format:check` / `typecheck` pass
+- [x] `src/lib/api.ts`: `isAuthRequiredError()` が `FORBIDDEN` を含まないことをテストで固定
+- [x] `src/commands/init.test.ts`: `FORBIDDEN` では自動再認証が起動しないこと
+- [x] `src/lib/tasks-api.test.ts`: Tasks 側も同じ振り分けになること（`mapApiError()` 共用の確認）
+- [x] `spec/output.md`: Error Codes 表に `FORBIDDEN` を追加
+- [x] `spec/overview.md`: 必要なら Exit Codes の説明を補足
+- [x] `vitest run src tests/integration` / `lint` / `format:check` / `typecheck` pass
+      （E2E は実 API を叩くため本作業では未実行）
 
 ## E2E Test
 
@@ -152,18 +153,19 @@ Error: <API の原文> You may not have permission to change this event; only it
 - [ ] 書き込み可能なカレンダーでは同じ操作が成功すること（対照）
 
 環境変数 `GCAL_E2E_READONLY_CALENDAR_ID` で読み取り専用カレンダーを指定し、未設定ならスキップする。
+`tests/e2e/forbidden.test.ts` に実装済み。**未実行**（実 API を叩くため）。
 非主催者イベント（`forbiddenForNonOrganizer`）は第2アカウントが要るため E2E では扱わず、
 ユニットテストでモックする。
 
 ## Acceptance Criteria
 
 - [x] 実 API が返す 403 の `reason` を確認し、その根拠がタスクファイルに記録されている
-- [ ] 権限不足の 403 が `FORBIDDEN` / 終了コード 1 になる
-- [ ] 認証由来の 403（スコープ不足）は従来どおり `AUTH_REQUIRED` / 終了コード 2 のまま
-- [ ] `reason` が読めない 403 は `AUTH_REQUIRED` に倒れる（安全側の既定）
-- [ ] 401 の扱いは一切変わらない
-- [ ] `gcal init` が `FORBIDDEN` で自動再認証を起動しない
-- [ ] Calendar 側と Tasks 側の両方で同じ振り分けになる
-- [ ] エラーメッセージが API の原文を保ち、原因を断定していない
-- [ ] `spec/output.md` の Error Codes 表が実装と一致している
-- [ ] 既存テストが pass する
+- [x] 権限不足の 403 が `FORBIDDEN` / 終了コード 1 になる
+- [x] 認証由来の 403（スコープ不足）は従来どおり `AUTH_REQUIRED` / 終了コード 2 のまま
+- [x] `reason` が読めない 403 は `AUTH_REQUIRED` に倒れる（安全側の既定）
+- [x] 401 の扱いは一切変わらない
+- [x] `gcal init` が `FORBIDDEN` で自動再認証を起動しない
+- [x] Calendar 側と Tasks 側の両方で同じ振り分けになる
+- [x] エラーメッセージが API の原文を保ち、原因を断定していない
+- [x] `spec/output.md` の Error Codes 表が実装と一致している
+- [x] 既存テストが pass する

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -160,6 +160,19 @@ describe("handleError", () => {
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.ARGUMENT);
   });
 
+  it("exits with code 1 and keeps the FORBIDDEN code for permission errors", () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const error = new Error("You need to have writer access to this calendar.");
+    (error as Error & { code: ErrorCode }).code = "FORBIDDEN";
+    handleError(error, "json");
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.GENERAL);
+    const parsed = JSON.parse(stderrSpy.mock.calls.map((c) => c[0]).join(""));
+    expect(parsed.error.code).toBe("FORBIDDEN");
+  });
+
   it("uses API_ERROR code in JSON output for general errors", () => {
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ function getErrorCode(error: unknown): ErrorCode {
       "NOT_FOUND",
       "INVALID_ARGS",
       "API_ERROR",
+      "FORBIDDEN",
       "CONFIG_ERROR",
     ];
     if (validCodes.includes(code as ErrorCode)) {

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -300,6 +300,17 @@ describe("handleInit", () => {
     expect(output.join("\n")).toContain("Not authenticated");
   });
 
+  it("does not auto-authenticate when listCalendars throws FORBIDDEN", async () => {
+    const forbidden = new ApiError("FORBIDDEN", "You need to have writer access to this calendar.");
+    const listCalendars = vi.fn().mockRejectedValue(forbidden);
+    const requestAuth = vi.fn().mockResolvedValue(undefined);
+    const opts = makeOpts({ listCalendars, requestAuth });
+
+    await expect(handleInit(opts)).rejects.toThrow("writer access");
+    expect(requestAuth).not.toHaveBeenCalled();
+    expect(listCalendars).toHaveBeenCalledTimes(1);
+  });
+
   it("auto-authenticates when listCalendars throws AUTH_REQUIRED", async () => {
     const authError = new ApiError("AUTH_REQUIRED", "Not authenticated");
     let callCount = 0;

--- a/src/lib/api-utils.test.ts
+++ b/src/lib/api-utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { isGoogleApiError, mapApiError } from "./api-utils.ts";
+import { ApiError } from "./api.ts";
+
+/**
+ * Shape captured from the live API on 2026-08-21: `events.insert` against a
+ * read-only subscribed calendar. `reason` is readable straight off `e.errors`.
+ */
+function makeApiError(
+  code: number,
+  message: string,
+  reason?: string,
+): Error & { code: number; errors?: { domain?: string; reason?: string; message?: string }[] } {
+  const error = Object.assign(new Error(message), { code });
+  if (reason === undefined) {
+    return error;
+  }
+  return Object.assign(error, { errors: [{ domain: "calendar", reason, message }] });
+}
+
+describe("isGoogleApiError", () => {
+  it("accepts an Error carrying a numeric code", () => {
+    expect(isGoogleApiError(makeApiError(403, "Forbidden"))).toBe(true);
+  });
+
+  it("rejects a plain Error and a non-Error value", () => {
+    expect(isGoogleApiError(new Error("boom"))).toBe(false);
+    expect(isGoogleApiError({ code: 403 })).toBe(false);
+  });
+});
+
+describe("mapApiError", () => {
+  function mapped(error: unknown): ApiError {
+    try {
+      mapApiError(error);
+    } catch (e: unknown) {
+      return e as ApiError;
+    }
+    throw new Error("mapApiError did not throw");
+  }
+
+  it("maps 401 to AUTH_REQUIRED regardless of reason", () => {
+    const error = mapped(makeApiError(401, "Invalid Credentials", "authError"));
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("AUTH_REQUIRED");
+    expect(error.message).toBe("Invalid Credentials");
+  });
+
+  it("maps 403 requiredAccessLevel to FORBIDDEN, keeping the API message", () => {
+    const error = mapped(
+      makeApiError(403, "You need to have writer access to this calendar.", "requiredAccessLevel"),
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("FORBIDDEN");
+    expect(error.message).toContain("You need to have writer access to this calendar.");
+    expect(error.message).toContain("may not have permission");
+  });
+
+  it("maps 403 forbiddenForNonOrganizer to FORBIDDEN", () => {
+    const error = mapped(
+      makeApiError(403, "Forbidden for non organizer", "forbiddenForNonOrganizer"),
+    );
+    expect(error.code).toBe("FORBIDDEN");
+  });
+
+  it("keeps 403 insufficientPermissions on AUTH_REQUIRED (re-auth does fix it)", () => {
+    const error = mapped(makeApiError(403, "Insufficient Permission", "insufficientPermissions"));
+    expect(error.code).toBe("AUTH_REQUIRED");
+    expect(error.message).toBe("Insufficient Permission");
+  });
+
+  it("falls back to AUTH_REQUIRED for an unknown 403 reason", () => {
+    const error = mapped(makeApiError(403, "Forbidden", "someReasonWeHaveNeverSeen"));
+    expect(error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("falls back to AUTH_REQUIRED when the 403 carries no reason", () => {
+    const error = mapped(makeApiError(403, "Forbidden"));
+    expect(error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("maps 404 to NOT_FOUND", () => {
+    expect(mapped(makeApiError(404, "Not Found")).code).toBe("NOT_FOUND");
+  });
+
+  it("maps other HTTP errors to API_ERROR", () => {
+    expect(mapped(makeApiError(500, "Backend Error")).code).toBe("API_ERROR");
+  });
+
+  it("rethrows values that are not Google API errors", () => {
+    const original = new Error("boom");
+    expect(mapped(original)).toBe(original);
+  });
+});

--- a/src/lib/api-utils.test.ts
+++ b/src/lib/api-utils.test.ts
@@ -54,21 +54,30 @@ describe("mapApiError", () => {
     expect(error.message).toBe("Invalid Credentials");
   });
 
-  it("maps 403 requiredAccessLevel to FORBIDDEN, keeping the API message", () => {
+  it("maps 403 requiredAccessLevel to FORBIDDEN with an access-level hint", () => {
     const error = mapped(
       makeApiError(403, "You need to have writer access to this calendar.", "requiredAccessLevel"),
     );
     expect(error).toBeInstanceOf(ApiError);
     expect(error.code).toBe("FORBIDDEN");
-    expect(error.message).toContain("You need to have writer access to this calendar.");
-    expect(error.message).toContain("may not have permission");
+    expect(error.message).toBe(
+      "You need to have writer access to this calendar. " +
+        "Re-authenticating will not help; you need write access here.",
+    );
+    // No event and no organizer is involved here -- an insert was refused.
+    expect(error.message).not.toContain("organizer");
   });
 
-  it("maps 403 forbiddenForNonOrganizer to FORBIDDEN", () => {
+  it("maps 403 forbiddenForNonOrganizer to FORBIDDEN with an organizer hint", () => {
     const error = mapped(
       makeApiError(403, "Forbidden for non organizer", "forbiddenForNonOrganizer"),
     );
     expect(error.code).toBe("FORBIDDEN");
+    // Joined with a plain space: the API's own wording is passed through untouched.
+    expect(error.message).toBe(
+      "Forbidden for non organizer " +
+        "Re-authenticating will not help; only the organizer can change this event.",
+    );
   });
 
   it("keeps 403 insufficientPermissions on AUTH_REQUIRED (re-auth does fix it)", () => {
@@ -85,6 +94,48 @@ describe("mapApiError", () => {
   it("falls back to AUTH_REQUIRED when the 403 carries no reason", () => {
     const error = mapped(makeApiError(403, "Forbidden"));
     expect(error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("falls back to AUTH_REQUIRED when the 403 carries an empty errors array", () => {
+    const error = mapped(Object.assign(new Error("Forbidden"), { code: 403, errors: [] }));
+    expect(error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("finds a routed reason that is not the first detail", () => {
+    const error = mapped(
+      Object.assign(new Error("Forbidden"), {
+        code: 403,
+        errors: [
+          { domain: "global", reason: "somethingElse", message: "Forbidden" },
+          { domain: "calendar", reason: "forbiddenForNonOrganizer", message: "Forbidden" },
+        ],
+      }),
+    );
+    expect(error.code).toBe("FORBIDDEN");
+  });
+
+  // The captured error mirrored the same array under response.data.error.errors;
+  // read it when the top-level shortcut is missing.
+  it("reads the reason from response.data.error.errors when errors is absent", () => {
+    const error = mapped(
+      Object.assign(new Error("You need to have writer access to this calendar."), {
+        code: 403,
+        response: {
+          data: {
+            error: {
+              errors: [
+                {
+                  domain: "calendar",
+                  reason: "requiredAccessLevel",
+                  message: "You need to have writer access to this calendar.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    expect(error.code).toBe("FORBIDDEN");
   });
 
   it("maps 404 to NOT_FOUND", () => {

--- a/src/lib/api-utils.test.ts
+++ b/src/lib/api-utils.test.ts
@@ -39,9 +39,17 @@ describe("mapApiError", () => {
     throw new Error("mapApiError did not throw");
   }
 
-  it("maps 401 to AUTH_REQUIRED regardless of reason", () => {
+  it("maps 401 to AUTH_REQUIRED", () => {
     const error = mapped(makeApiError(401, "Invalid Credentials", "authError"));
     expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("AUTH_REQUIRED");
+    expect(error.message).toBe("Invalid Credentials");
+  });
+
+  // An expired token must never be reported as a permission problem: that would
+  // tell the caller not to re-authenticate, the inverse of the right answer.
+  it("maps 401 to AUTH_REQUIRED even when it carries a permission reason", () => {
+    const error = mapped(makeApiError(401, "Invalid Credentials", "requiredAccessLevel"));
     expect(error.code).toBe("AUTH_REQUIRED");
     expect(error.message).toBe("Invalid Credentials");
   });

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -2,7 +2,16 @@ import { ApiError } from "./api.ts";
 
 export const MAX_PAGES = 100;
 
-export function isGoogleApiError(error: unknown): error is Error & { code: number } {
+/** Per-error detail Google puts on `error.errors` (also mirrored in the response body). */
+interface GoogleApiErrorDetail {
+  domain?: string;
+  reason?: string;
+  message?: string;
+}
+
+export function isGoogleApiError(
+  error: unknown,
+): error is Error & { code: number; errors?: GoogleApiErrorDetail[] } {
   return (
     error instanceof Error &&
     "code" in error &&
@@ -10,8 +19,21 @@ export function isGoogleApiError(error: unknown): error is Error & { code: numbe
   );
 }
 
+/**
+ * 403 reasons that re-authenticating cannot fix. Only reasons observed on the real
+ * API belong here; an unknown reason falls back to AUTH_REQUIRED, which at worst
+ * wastes a re-auth instead of hiding a genuine auth problem.
+ */
+const FORBIDDEN_REASONS: readonly string[] = ["requiredAccessLevel", "forbiddenForNonOrganizer"];
+
+const FORBIDDEN_HINT = "You may not have permission to change this event; only its organizer can.";
+
 export function mapApiError(error: unknown): never {
   if (isGoogleApiError(error)) {
+    const reason = error.errors?.[0]?.reason;
+    if (error.code === 403 && reason !== undefined && FORBIDDEN_REASONS.includes(reason)) {
+      throw new ApiError("FORBIDDEN", `${error.message} ${FORBIDDEN_HINT}`);
+    }
     if (error.code === 401 || error.code === 403) {
       throw new ApiError("AUTH_REQUIRED", error.message);
     }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -9,9 +9,11 @@ interface GoogleApiErrorDetail {
   message?: string;
 }
 
-export function isGoogleApiError(
-  error: unknown,
-): error is Error & { code: number; errors?: GoogleApiErrorDetail[] } {
+export function isGoogleApiError(error: unknown): error is Error & {
+  code: number;
+  errors?: GoogleApiErrorDetail[];
+  response?: { data?: { error?: { errors?: GoogleApiErrorDetail[] } } };
+} {
   return (
     error instanceof Error &&
     "code" in error &&
@@ -20,19 +22,37 @@ export function isGoogleApiError(
 }
 
 /**
- * 403 reasons that re-authenticating cannot fix. Only reasons observed on the real
- * API belong here; an unknown reason falls back to AUTH_REQUIRED, which at worst
- * wastes a re-auth instead of hiding a genuine auth problem.
+ * The 403 reasons observed on the real API that re-authenticating cannot fix,
+ * each with what the user can actually do about it. Nothing outside this map is
+ * routed to FORBIDDEN: an unrecognised reason falls back to AUTH_REQUIRED, which
+ * at worst wastes a re-auth instead of hiding a genuine auth problem. Add a
+ * reason only after seeing it come back from the real API.
  */
-const FORBIDDEN_REASONS: readonly string[] = ["requiredAccessLevel", "forbiddenForNonOrganizer"];
+const FORBIDDEN_HINTS: Readonly<Record<string, string>> = {
+  requiredAccessLevel: "Re-authenticating will not help; you need write access here.",
+  forbiddenForNonOrganizer:
+    "Re-authenticating will not help; only the organizer can change this event.",
+};
 
-const FORBIDDEN_HINT = "You may not have permission to change this event; only its organizer can.";
+/** The hint for the first detail naming a reason we route, or undefined. */
+function forbiddenHint(details: GoogleApiErrorDetail[] | undefined): string | undefined {
+  for (const detail of details ?? []) {
+    const hint = detail.reason === undefined ? undefined : FORBIDDEN_HINTS[detail.reason];
+    if (hint !== undefined) {
+      return hint;
+    }
+  }
+  return undefined;
+}
 
 export function mapApiError(error: unknown): never {
   if (isGoogleApiError(error)) {
-    const reason = error.errors?.[0]?.reason;
-    if (error.code === 403 && reason !== undefined && FORBIDDEN_REASONS.includes(reason)) {
-      throw new ApiError("FORBIDDEN", `${error.message} ${FORBIDDEN_HINT}`);
+    if (error.code === 403) {
+      // Both carry the same array in the pinned googleapis version; read either.
+      const hint = forbiddenHint(error.errors ?? error.response?.data?.error?.errors);
+      if (hint !== undefined) {
+        throw new ApiError("FORBIDDEN", `${error.message} ${hint}`);
+      }
     }
     if (error.code === 401 || error.code === 403) {
       throw new ApiError("AUTH_REQUIRED", error.message);

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -8,6 +8,7 @@ import {
   createEvent,
   updateEvent,
   deleteEvent,
+  isAuthRequiredError,
   ApiError,
   MAX_PAGES,
   type GoogleCalendarApi,
@@ -791,6 +792,70 @@ describe("API error mapping", () => {
     const error = await listEvents(api, "cal1", "Cal").catch((e) => e);
     expect(error).toBeInstanceOf(ApiError);
     expect(error).toMatchObject({ code: "AUTH_REQUIRED" });
+  });
+
+  it("maps a 403 carrying a permission reason to FORBIDDEN", async () => {
+    const forbidden = Object.assign(new Error("You need to have writer access to this calendar."), {
+      code: 403,
+      errors: [
+        {
+          domain: "calendar",
+          reason: "requiredAccessLevel",
+          message: "You need to have writer access to this calendar.",
+        },
+      ],
+    });
+    const api: GoogleCalendarApi = {
+      calendarList: { list: vi.fn() },
+      events: {
+        list: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn().mockRejectedValue(forbidden),
+        patch: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+
+    const input: CreateEventInput = {
+      title: "Test",
+      start: "2024-03-15T09:00:00Z",
+      end: "2024-03-15T10:00:00Z",
+      allDay: false,
+    };
+
+    const error = await createEvent(api, "cal1", "Cal", input).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("maps a 403 on --remove-meet to FORBIDDEN rather than asking for re-auth", async () => {
+    const forbidden = Object.assign(new Error("Forbidden for non organizer"), {
+      code: 403,
+      errors: [
+        {
+          domain: "calendar",
+          reason: "forbiddenForNonOrganizer",
+          message: "Forbidden for non organizer",
+        },
+      ],
+    });
+    const api: GoogleCalendarApi = {
+      calendarList: { list: vi.fn() },
+      events: {
+        list: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn(),
+        patch: vi.fn().mockRejectedValue(forbidden),
+        delete: vi.fn(),
+      },
+    };
+
+    const error = await updateEvent(api, "cal1", "Cal", "evt1", { removeMeet: true }).catch(
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ code: "FORBIDDEN" });
+    expect((error as ApiError).message).toContain("Forbidden for non organizer");
   });
 
   it("maps other HTTP errors to API_ERROR", async () => {
@@ -1601,5 +1666,21 @@ describe("deleteEvent", () => {
     const error = await deleteEvent(api, "cal1", "evt1").catch((e: unknown) => e);
     expect(error).toBeInstanceOf(ApiError);
     expect(error).toMatchObject({ code: "API_ERROR" });
+  });
+});
+
+describe("isAuthRequiredError", () => {
+  it("is true for the codes a re-auth can fix", () => {
+    expect(isAuthRequiredError(new ApiError("AUTH_REQUIRED", "Not authenticated"))).toBe(true);
+    expect(isAuthRequiredError(new ApiError("AUTH_EXPIRED", "Token expired"))).toBe(true);
+  });
+
+  it("is false for FORBIDDEN -- re-authenticating does not grant permission", () => {
+    expect(isAuthRequiredError(new ApiError("FORBIDDEN", "You need writer access."))).toBe(false);
+  });
+
+  it("is false for other codes and for non-ApiError values", () => {
+    expect(isAuthRequiredError(new ApiError("API_ERROR", "Backend Error"))).toBe(false);
+    expect(isAuthRequiredError(new Error("boom"))).toBe(false);
   });
 });

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -837,6 +837,10 @@ describe("errorCodeToExitCode", () => {
   it("maps CONFIG_ERROR to exit code 1", () => {
     expect(errorCodeToExitCode("CONFIG_ERROR")).toBe(1);
   });
+
+  it("maps FORBIDDEN to exit code 1", () => {
+    expect(errorCodeToExitCode("FORBIDDEN")).toBe(1);
+  });
 });
 
 describe("formatHiddenAllDayWarning", () => {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -270,6 +270,7 @@ const ERROR_CODE_EXIT_MAP: Record<ErrorCode, number> = {
   NOT_FOUND: ExitCode.GENERAL,
   INVALID_ARGS: ExitCode.ARGUMENT,
   API_ERROR: ExitCode.GENERAL,
+  FORBIDDEN: ExitCode.GENERAL,
   CONFIG_ERROR: ExitCode.GENERAL,
 };
 

--- a/src/lib/tasks-api.test.ts
+++ b/src/lib/tasks-api.test.ts
@@ -604,6 +604,47 @@ describe("API error mapping", () => {
     expect(error).toMatchObject({ code: "AUTH_REQUIRED" });
   });
 
+  // mapApiError() is shared with the Calendar client, so the 403 split applies here too.
+  it("maps a 403 carrying a permission reason to FORBIDDEN", async () => {
+    const forbidden = Object.assign(new Error("Forbidden"), {
+      code: 403,
+      errors: [{ domain: "global", reason: "requiredAccessLevel", message: "Forbidden" }],
+    });
+    const client: GoogleTasksClient = {
+      tasklists: { list: vi.fn() },
+      tasks: {
+        list: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn().mockRejectedValue(forbidden),
+        patch: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+
+    const error = await createTask(client, "@default", "My Tasks", { title: "Test" }).catch(
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("keeps a 403 scope error on AUTH_REQUIRED", async () => {
+    const insufficient = Object.assign(new Error("Insufficient Permission"), {
+      code: 403,
+      errors: [
+        { domain: "global", reason: "insufficientPermissions", message: "Insufficient Permission" },
+      ],
+    });
+    const client: GoogleTasksClient = {
+      tasklists: { list: vi.fn().mockRejectedValue(insufficient) },
+      tasks: { list: vi.fn(), get: vi.fn(), insert: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+    };
+
+    const error = await listTaskLists(client).catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ code: "AUTH_REQUIRED" });
+  });
+
   it("maps other HTTP errors to API_ERROR", async () => {
     const client: GoogleTasksClient = {
       tasklists: { list: vi.fn() },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,7 @@ export type ErrorCode =
   | "NOT_FOUND"
   | "INVALID_ARGS"
   | "API_ERROR"
+  | "FORBIDDEN"
   | "CONFIG_ERROR";
 
 export interface SuccessResponse<T> {

--- a/tests/e2e/forbidden.test.ts
+++ b/tests/e2e/forbidden.test.ts
@@ -65,7 +65,8 @@ describe.runIf(enabled)(
       const payload = JSON.parse(result.stderr) as ErrorPayload;
       expect(payload.success).toBe(false);
       expect(payload.error.code).toBe("FORBIDDEN");
-      // The API wording is kept, and nothing tells the user to authenticate again.
+      // The API wording is kept, and the user is told a re-auth is not the fix.
+      expect(payload.error.message).toContain("Re-authenticating will not help");
       expect(payload.error.message).not.toContain("gcal auth");
       expect(payload.error.message.toLowerCase()).not.toContain("not authenticated");
     });

--- a/tests/e2e/forbidden.test.ts
+++ b/tests/e2e/forbidden.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterAll } from "vitest";
+import {
+  runCli,
+  testEventTitle,
+  todayDate,
+  TestCleanup,
+  hasCredentials,
+  E2E_TIMEOUT,
+} from "./helpers.ts";
+
+/**
+ * A read-only calendar is the only way to draw a real 403 without a second
+ * account, and it cannot be provisioned from here -- point
+ * GCAL_E2E_READONLY_CALENDAR_ID at a subscribed or read-access calendar
+ * (e.g. `...@import.calendar.google.com`) to enable this suite.
+ */
+const readOnlyCalendarId = process.env["GCAL_E2E_READONLY_CALENDAR_ID"] ?? "";
+const enabled = hasCredentials() && readOnlyCalendarId !== "";
+
+/** YYYY-MM-DD `days` after today, in local time. */
+function dateOffset(days: number): string {
+  const [y, m, d] = todayDate().split("-").map(Number);
+  const date = new Date(y!, m! - 1, d! + days);
+  const yy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+const start = `${dateOffset(58)}T10:00`;
+
+interface ErrorPayload {
+  success: false;
+  error: { code: string; message: string };
+}
+
+interface EventPayload {
+  data: { event: { id: string } };
+}
+
+describe.runIf(enabled)(
+  "E2E: permission errors are not authentication errors",
+  () => {
+    const cleanup = new TestCleanup();
+
+    afterAll(async () => {
+      await cleanup.deleteAll();
+    });
+
+    it("add to a read-only calendar returns FORBIDDEN and exit 1", async () => {
+      // runCli, not runCliJson: the error goes to stderr and leaves stdout empty.
+      const result = await runCli(
+        "-f",
+        "json",
+        "add",
+        "-c",
+        readOnlyCalendarId,
+        "--title",
+        testEventTitle("Forbidden"),
+        "--start",
+        start,
+      );
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stderr) as ErrorPayload;
+      expect(payload.success).toBe(false);
+      expect(payload.error.code).toBe("FORBIDDEN");
+      // The API wording is kept, and nothing tells the user to authenticate again.
+      expect(payload.error.message).not.toContain("gcal auth");
+      expect(payload.error.message.toLowerCase()).not.toContain("not authenticated");
+    });
+
+    it("the same add succeeds on a writable calendar", async () => {
+      const result = await runCli(
+        "-f",
+        "json",
+        "add",
+        "--title",
+        testEventTitle("Forbidden control"),
+        "--start",
+        start,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = JSON.parse(result.stdout) as EventPayload;
+      cleanup.track(payload.data.event.id);
+    });
+  },
+  E2E_TIMEOUT,
+);


### PR DESCRIPTION
Implements `spec/tasks/044-forbidden-vs-auth.md`.

## Problem

`mapApiError()` mapped HTTP 401 and 403 to the same `AUTH_REQUIRED` code, so a
permissions problem was reported as "authentication required" and exited 2.
Re-authenticating never fixes it, and `gcal init` (which branches on
`isAuthRequiredError()`) would launch an OAuth flow that cannot help.

## What changed

- `src/lib/api-utils.ts`
  - `isGoogleApiError()` is widened to expose `errors?: { domain?, reason?, message? }[]`.
    The live 403 captured for this task carries `reason` directly on `e.errors[0]`, so
    there is no need to dig into `e.response.data.error.errors`.
  - A 403 whose first `reason` is `requiredAccessLevel` or `forbiddenForNonOrganizer`
    now throws `ApiError("FORBIDDEN", ...)`. Everything else about 401/403 is unchanged.
- `src/types/index.ts` — `ErrorCode` gains `FORBIDDEN`.
- `src/lib/output.ts` — `ERROR_CODE_EXIT_MAP.FORBIDDEN = ExitCode.GENERAL` (1).
- `src/cli.ts` — `FORBIDDEN` added to `getErrorCode()`'s `validCodes`, so the code
  survives into JSON output instead of being flattened to `API_ERROR`.
- `spec/output.md` / `spec/overview.md` — Error Codes table and an exit-code note.

## Contract change (please read)

**This adds a new `ErrorCode` value, `FORBIDDEN`, to the JSON error contract.**
It is a new member of an existing enum, not a new field, so consumers that only
matched `API_ERROR` are unaffected — but consumers that branch on `AUTH_REQUIRED`
will now see `FORBIDDEN` for some errors they used to see as `AUTH_REQUIRED`.

**Exit codes that move:** a 403 with reason `requiredAccessLevel` or
`forbiddenForNonOrganizer` goes from exit 2 (AUTH) to exit 1 (GENERAL).
Nothing else moves. 401 is untouched; 403 with `insufficientPermissions`
(OAuth scope — a real re-auth does fix that) stays `AUTH_REQUIRED`/2; a 403 with
an unrecognised reason, or with no `errors` array at all, also stays
`AUTH_REQUIRED`/2 as the safe default.

## Design decisions

- **Only reasons observed on the real API are routed to `FORBIDDEN`.** The task
  file records a live capture (`events.insert` against a read-only subscribed
  calendar → `reason: "requiredAccessLevel"`). `forbiddenForNonOrganizer` is
  documented by Google and named in the task's routing table, so it is included;
  it was not reproducible without a second account. No other reason strings were
  invented — unknown reasons fall back to `AUTH_REQUIRED`, which at worst wastes
  a re-auth rather than hiding a genuine auth problem.
- **`FORBIDDEN` is deliberately excluded from `isAuthRequiredError()`**, which is
  what stops `gcal init` from starting the pointless re-auth. A test pins this.
- **`mapApiError()` is shared by `src/lib/api.ts` and `src/lib/tasks-api.ts`**, so
  Google Tasks commands get the same split. Both paths are covered by tests.
- The message keeps the API's own wording and appends the hint from the task file
  verbatim, so nothing asserts a cause the API did not state.

## Message wording (changed after review)

The task file originally specified a single hint string appended to every
`FORBIDDEN` error. I flagged it as wrong, the reviewer upheld it, and the owner
approved retracting it. Each routed reason now carries its own wording:

| reason | appended after the API's own message |
|---|---|
| `requiredAccessLevel` | `Re-authenticating will not help; you need write access here.` |
| `forbiddenForNonOrganizer` | `Re-authenticating will not help; only the organizer can change this event.` |

The routed reasons are **derived from that map**, so the list and the wording
cannot drift apart. Both keep the "re-authenticating will not help" signal, which
is the whole point of the split. The retraction is recorded inline in
`spec/tasks/044-forbidden-vs-auth.md`.

Two robustness items from the same review are folded in: the reason is looked for
across *all* details rather than only `errors[0]`, and `e.errors` falls back to
`e.response?.data?.error?.errors` (the captured error carried the same array in
both places).

## Testing

- New `src/lib/api-utils.test.ts` (15 tests) drives the split directly: 401 both
  with and without a routed reason, each routed 403 reason with its exact message,
  `insufficientPermissions`, an unknown reason, a 403 with no `errors`, an empty
  `errors` array, a routed reason in a later detail, the `response.data` fallback,
  404, 500, and non-API values. Written first and watched fail before the
  implementation existed.

- **Mutation check.** The review found a survivor: deleting `error.code === 403 &&`
  from the guard left all tests green, so a 401 carrying `requiredAccessLevel`
  would map to `FORBIDDEN` -- telling the caller not to re-authenticate when that
  is exactly the fix. The old test named "regardless of reason" passed a reason
  that was not routed, so it held either way. Fixed, and I confirmed the new case
  fails against that mutation before relying on it.
- `src/lib/api.test.ts` — 403 → `FORBIDDEN` through `createEvent`, and through
  `updateEvent --remove-meet` (the `mapWriteError()` path, so the `--meet` 400
  hint does not swallow it); plus a new `isAuthRequiredError` block pinning that
  `FORBIDDEN` is excluded.
- `src/lib/tasks-api.test.ts` — the same split via the Tasks client.
- `src/commands/init.test.ts` — `FORBIDDEN` does not trigger `requestAuth`.
- `src/lib/output.test.ts` / `src/cli.test.ts` — exit code 1 and the code surviving
  into JSON output.
- `vitest run src tests/integration`: **913 passed, 0 failed**. `typecheck`, `lint`,
  `format:check` all clean.

**Not verified:** `tests/e2e/forbidden.test.ts` is written but **was not executed**.
It needs a read-only calendar via `GCAL_E2E_READONLY_CALENDAR_ID` and skips when
unset, and running it would hit the live API while other work was in flight.
`forbiddenForNonOrganizer` is unit-tested with a mock only; it has never been seen
from the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YB6iUb89Fr1HYsQucbgoo
