### PR TITLE
feat: make partial calendar failures machine-readable in list and search

### DIFF
--- a/spec/commands.md
+++ b/spec/commands.md
@@ -66,6 +66,14 @@ event it hides is reported on stderr with its date and title. See
 Quiet mode (`-q`): Compact one-line format: `MM/DD HH:MM-HH:MM Title`. Warnings
 still go to stderr, so stdout stays clean for piping.
 
+Partial failures: every enabled calendar is queried at once. A calendar that
+fails is warned about on stderr and listed in `data.failed_calendars` (always
+present, `[]` when nothing failed), and the events fetched from the other
+calendars are still returned. If **every** calendar fails the first error is
+raised instead, so a fetch that returned nothing never reports success -- this
+is what the usual single-calendar setup hits. See
+[output.md](./output.md#partial-fetch-failures).
+
 ### `gcal search`
 
 Search events by keyword.
@@ -111,8 +119,13 @@ Tip: Use --days <n> or --from/--to to change the search range.
 stderr in the same format.
 
 Quiet mode (`-q`): Same compact format as `list` (`MM/DD HH:MM-HH:MM Title`).
-Unlike `list`, `search` suppresses **all** stderr messages under `--quiet`,
-including the `--busy` notice.
+Unlike `list`, `search` suppresses its stderr messages under `--quiet`,
+including the `--busy` notice. The one exception is the failed-calendar warning
+below, which is a failure notice rather than data.
+
+Partial failures: identical to `list` -- failed calendars are reported on stderr
+and in `data.failed_calendars`, and a fetch where every calendar failed raises
+the first error.
 
 ### `gcal add`
 

--- a/spec/output.md
+++ b/spec/output.md
@@ -72,8 +72,35 @@ Rules:
   reported.
 - At most 5 titles are listed; the rest are summarised as `... and N more`.
 - `gcal list` emits the notice in every mode including `--quiet` and `-f json`.
-  `gcal search` suppresses all stderr output under `--quiet`, so the notice is
-  omitted there.
+  `gcal search` suppresses its stderr output under `--quiet` apart from the
+  failed-calendar warning, so the notice is omitted there.
+
+#### Partial Fetch Failures
+
+`gcal list` and `gcal search` query every enabled calendar at once. A calendar
+that fails is warned about on **stderr** and the remaining calendars are still
+listed, with one line after the listing so a stdout reader knows it is
+incomplete:
+
+```
+Warning: failed to fetch calendar "Work": ApiError: Rate Limit Exceeded ...   (stderr)
+
+2026-01-24 (Fri)
+  10:00-11:00   Team Meeting (Main Calendar) [busy]
+
+Note: 1 calendar could not be fetched (see warnings above).
+```
+
+Rules:
+
+- The `Note:` line is omitted under `--quiet` (`-q` is a minimal-output
+  contract); the stderr warning is not, in either command. A failed calendar is
+  a failure notice rather than data, so it is the one stderr message `search`
+  still emits under `--quiet`.
+- When **every** calendar fails, nothing is printed to stdout at all: the first
+  error is raised and handled as a normal error, so the exit code follows its
+  `error.code`. With the common single-calendar setup, "all failed" is simply
+  "the fetch failed".
 
 ### `gcal search` Text Output
 
@@ -197,6 +224,30 @@ Use `-f json` for machine-readable output.
 }
 ```
 
+`gcal list` and `gcal search` add `failed_calendars` to `data`:
+
+```json
+{
+  "success": true,
+  "data": {
+    "events": [ ... ],
+    "count": 3,
+    "failed_calendars": [
+      {
+        "id": "work@group.calendar.google.com",
+        "name": "Work",
+        "error": { "code": "RATE_LIMITED", "message": "Rate Limit Exceeded ..." }
+      }
+    ]
+  }
+}
+```
+
+The key is **always present**, `[]` when nothing failed, so an agent never has
+to test for it. A response with `failed_calendars: []` is the only one that
+covers every enabled calendar. When every calendar fails there is no success
+response at all -- the first error is returned as an error response.
+
 ### Error Response
 
 ```json
@@ -313,6 +364,23 @@ Meet かどうかを決められない。判定に使えるのは `conferenceSol
 `null` になる。`conference` は `type` と `uri` がどちらも分からないうちは
 `{"type": null, "uri": null}` ではなく `null` を返す（説明できることが何も無いため）。
 その場合は数秒後に `gcal show` で取得できる（`spec/commands.md` の `gcal add` を参照）。
+
+### FailedCalendar
+
+A calendar whose fetch failed while at least one other calendar succeeded.
+`error.code` is the `ErrorCode` of the underlying `ApiError`, or `API_ERROR`
+when the failure carries no code of its own.
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "error": {
+    "code": "ErrorCode",
+    "message": "string"
+  }
+}
+```
 
 ### Calendar
 

--- a/spec/output.md
+++ b/spec/output.md
@@ -248,6 +248,12 @@ to test for it. A response with `failed_calendars: []` is the only one that
 covers every enabled calendar. When every calendar fails there is no success
 response at all -- the first error is returned as an error response.
 
+One case still returns `count: 0` with `failed_calendars: []` without any
+calendar having been queried: a config where no calendar has `enabled = true`
+(or a `-c` selection matching none). Nothing failed, so this is a success, but
+it is not the same as "queried and empty" -- `gcal calendars` shows which are
+enabled.
+
 ### Error Response
 
 ```json
@@ -428,7 +434,8 @@ when the failure carries no code of its own.
         "calendar_name": "Main Calendar"
       }
     ],
-    "count": 2
+    "count": 2,
+    "failed_calendars": []
   }
 }
 ```
@@ -441,7 +448,8 @@ when the failure carries no code of its own.
   "data": {
     "query": "meeting",
     "events": [ ... ],
-    "count": 3
+    "count": 3,
+    "failed_calendars": []
   }
 }
 ```

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { CalendarEvent, AppConfig } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
+import { ApiError } from "../lib/api.ts";
 import {
   resolveDateRange,
   toDayRange,
@@ -312,6 +313,7 @@ describe("handleList", () => {
       data: {
         events: expect.any(Array),
         count: 2,
+        failed_calendars: [],
       },
     });
     expect(json.data.events).toHaveLength(2);
@@ -836,5 +838,137 @@ describe("handleList --busy all-day warning", () => {
     const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
     expect(warning).toContain("hidden by --busy");
     expect(() => JSON.parse(write.mock.calls[0]![0] as string)).not.toThrow();
+  });
+});
+
+describe("handleList partial calendar failures", () => {
+  const mainEvent = makeEvent({ id: "e1", calendar_id: "primary", calendar_name: "Main Calendar" });
+  const rateLimited = new ApiError("RATE_LIMITED", "Rate Limit Exceeded");
+
+  /** Deps whose listEvents rejects for the calendar ids listed in `failures`. */
+  function makeFailingDeps(failures: Record<string, Error>, config = makeConfig()) {
+    const write = vi.fn();
+    const writeErr = vi.fn();
+    const deps = makeDeps({
+      listEvents: vi.fn().mockImplementation(async (calendarId: string) => {
+        const error = failures[calendarId];
+        if (error) throw error;
+        return [mainEvent];
+      }),
+      loadConfig: vi.fn().mockReturnValue(config),
+      write,
+      writeErr,
+    });
+    return { deps, write, writeErr };
+  }
+
+  const jsonOf = (write: ReturnType<typeof vi.fn>) =>
+    JSON.parse(write.mock.calls[0]![0] as string) as {
+      data: { count: number; failed_calendars: unknown[] };
+    };
+
+  it("returns the events it could fetch and lists the failed calendar", async () => {
+    const { deps, write } = makeFailingDeps({
+      "work@group.calendar.google.com": rateLimited,
+    });
+
+    const result = await handleList({ today: true, format: "json", quiet: false }, deps);
+
+    expect(result.exitCode).toBe(ExitCode.SUCCESS);
+    const json = jsonOf(write);
+    expect(json.data.count).toBe(1);
+    expect(json.data.failed_calendars).toEqual([
+      {
+        id: "work@group.calendar.google.com",
+        name: "Work",
+        error: { code: "RATE_LIMITED", message: "Rate Limit Exceeded" },
+      },
+    ]);
+  });
+
+  it("falls back to API_ERROR when the failure is not an ApiError", async () => {
+    const { deps, write } = makeFailingDeps({
+      "work@group.calendar.google.com": new Error("socket hang up"),
+    });
+
+    await handleList({ today: true, format: "json", quiet: false }, deps);
+
+    expect(jsonOf(write).data.failed_calendars).toEqual([
+      {
+        id: "work@group.calendar.google.com",
+        name: "Work",
+        error: { code: "API_ERROR", message: "socket hang up" },
+      },
+    ]);
+  });
+
+  it("returns an empty failed_calendars array when every calendar succeeds", async () => {
+    const { deps, write } = makeFailingDeps({});
+
+    await handleList({ today: true, format: "json", quiet: false }, deps);
+
+    expect(jsonOf(write).data.failed_calendars).toEqual([]);
+  });
+
+  it("throws the first error when every calendar fails", async () => {
+    const { deps, write } = makeFailingDeps({
+      primary: rateLimited,
+      "work@group.calendar.google.com": new ApiError("FORBIDDEN", "Insufficient permission"),
+    });
+
+    await expect(handleList({ today: true, format: "json", quiet: false }, deps)).rejects.toBe(
+      rateLimited,
+    );
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  // The most common setup: one enabled calendar, so "all failed" is "it failed".
+  it("throws when the only configured calendar fails", async () => {
+    const { deps, write } = makeFailingDeps(
+      { primary: rateLimited },
+      makeConfig({ calendars: [{ id: "primary", name: "Main Calendar", enabled: true }] }),
+    );
+
+    await expect(handleList({ today: true, format: "json", quiet: false }, deps)).rejects.toBe(
+      rateLimited,
+    );
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("still warns on stderr about the failed calendar", async () => {
+    const { deps, writeErr } = makeFailingDeps({
+      "work@group.calendar.google.com": rateLimited,
+    });
+
+    await handleList({ today: true, format: "json", quiet: false }, deps);
+
+    const warning = writeErr.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(warning).toContain('failed to fetch calendar "Work"');
+    expect(warning).toContain("Rate Limit Exceeded");
+  });
+
+  it("notes the failure at the end of the text output", async () => {
+    const { deps, write } = makeFailingDeps({
+      "work@group.calendar.google.com": rateLimited,
+    });
+
+    await handleList({ today: true, format: "text", quiet: false }, deps);
+
+    const output = write.mock.calls[0]![0] as string;
+    expect(output).toContain("Test Event");
+    expect(
+      output.trimEnd().endsWith("Note: 1 calendar could not be fetched (see warnings above)."),
+    ).toBe(true);
+  });
+
+  it("omits the text note under --quiet but keeps the stderr warning", async () => {
+    const { deps, write, writeErr } = makeFailingDeps({
+      "work@group.calendar.google.com": rateLimited,
+    });
+
+    await handleList({ today: true, format: "text", quiet: true }, deps);
+
+    expect(write.mock.calls[0]![0] as string).not.toContain("could not be fetched");
+    expect(writeErr).toHaveBeenCalled();
   });
 });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,15 +1,8 @@
 import { Command } from "commander";
-import type {
-  CalendarEvent,
-  AppConfig,
-  CalendarConfig,
-  ErrorCode,
-  FailedCalendar,
-  OutputFormat,
-} from "../types/index.ts";
+import type { CalendarEvent, AppConfig, OutputFormat } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import type { ListEventsOptions } from "../lib/api.ts";
-import { ApiError } from "../lib/api.ts";
+import { fetchFromCalendars } from "../lib/multi-calendar.ts";
 import { resolveTimezone, formatDateTimeInZone, parseDateTimeInZone } from "../lib/timezone.ts";
 import { selectCalendars } from "../lib/config.ts";
 import { applyFilters, findHiddenAllDayEvents } from "../lib/filter.ts";
@@ -140,17 +133,6 @@ interface CommandResult {
   exitCode: number;
 }
 
-function toFailedCalendar(calendar: CalendarConfig, reason: unknown): FailedCalendar {
-  const code: ErrorCode = reason instanceof ApiError ? reason.code : "API_ERROR";
-  const message = reason instanceof Error ? reason.message : String(reason);
-  return { id: calendar.id, name: calendar.name, error: { code, message } };
-}
-
-function firstRejection(settled: PromiseSettledResult<unknown>[]): unknown {
-  const rejected = settled.find((result) => result.status === "rejected");
-  return rejected?.reason;
-}
-
 export async function handleList(
   options: ListOptions,
   deps: ListHandlerDeps,
@@ -181,25 +163,11 @@ export async function handleList(
   };
 
   const writeErr = deps.writeErr ?? (() => {});
-  const settled = await Promise.allSettled(
-    calendars.map((cal) => deps.listEvents(cal.id, cal.name, apiOptions)),
+  const { events: allEvents, failedCalendars } = await fetchFromCalendars(
+    calendars,
+    (cal) => deps.listEvents(cal.id, cal.name, apiOptions),
+    writeErr,
   );
-  const allEvents: CalendarEvent[] = [];
-  const failedCalendars: FailedCalendar[] = [];
-  for (let i = 0; i < settled.length; i++) {
-    const result = settled[i]!;
-    if (result.status === "fulfilled") {
-      allEvents.push(...result.value);
-    } else {
-      writeErr(`Warning: failed to fetch calendar "${calendars[i]!.name}": ${result.reason}`);
-      failedCalendars.push(toFailedCalendar(calendars[i]!, result.reason));
-    }
-  }
-
-  // Nothing came back at all: `count: 0` would claim the calendars are empty.
-  if (calendars.length > 0 && failedCalendars.length === calendars.length) {
-    throw firstRejection(settled);
-  }
 
   // Sort by start time
   allEvents.sort((a, b) => a.start.localeCompare(b.start));

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,12 +1,21 @@
 import { Command } from "commander";
-import type { CalendarEvent, AppConfig, OutputFormat } from "../types/index.ts";
+import type {
+  CalendarEvent,
+  AppConfig,
+  CalendarConfig,
+  ErrorCode,
+  FailedCalendar,
+  OutputFormat,
+} from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import type { ListEventsOptions } from "../lib/api.ts";
+import { ApiError } from "../lib/api.ts";
 import { resolveTimezone, formatDateTimeInZone, parseDateTimeInZone } from "../lib/timezone.ts";
 import { selectCalendars } from "../lib/config.ts";
 import { applyFilters, findHiddenAllDayEvents } from "../lib/filter.ts";
 import {
   formatEventListText,
+  formatFailedCalendarsNote,
   formatHiddenAllDayWarning,
   formatJsonSuccess,
   formatQuietText,
@@ -131,6 +140,17 @@ interface CommandResult {
   exitCode: number;
 }
 
+function toFailedCalendar(calendar: CalendarConfig, reason: unknown): FailedCalendar {
+  const code: ErrorCode = reason instanceof ApiError ? reason.code : "API_ERROR";
+  const message = reason instanceof Error ? reason.message : String(reason);
+  return { id: calendar.id, name: calendar.name, error: { code, message } };
+}
+
+function firstRejection(settled: PromiseSettledResult<unknown>[]): unknown {
+  const rejected = settled.find((result) => result.status === "rejected");
+  return rejected?.reason;
+}
+
 export async function handleList(
   options: ListOptions,
   deps: ListHandlerDeps,
@@ -165,13 +185,20 @@ export async function handleList(
     calendars.map((cal) => deps.listEvents(cal.id, cal.name, apiOptions)),
   );
   const allEvents: CalendarEvent[] = [];
+  const failedCalendars: FailedCalendar[] = [];
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]!;
     if (result.status === "fulfilled") {
       allEvents.push(...result.value);
     } else {
       writeErr(`Warning: failed to fetch calendar "${calendars[i]!.name}": ${result.reason}`);
+      failedCalendars.push(toFailedCalendar(calendars[i]!, result.reason));
     }
+  }
+
+  // Nothing came back at all: `count: 0` would claim the calendars are empty.
+  if (calendars.length > 0 && failedCalendars.length === calendars.length) {
+    throw firstRejection(settled);
   }
 
   // Sort by start time
@@ -193,14 +220,21 @@ export async function handleList(
 
   // Output
   if (options.format === "json") {
-    deps.write(formatJsonSuccess({ events: filtered, count: filtered.length }));
+    deps.write(
+      formatJsonSuccess({
+        events: filtered,
+        count: filtered.length,
+        failed_calendars: failedCalendars,
+      }),
+    );
   } else {
     const dayRange = toDayRange(dateRange);
     if (options.quiet) {
       deps.write(formatQuietText(filtered, dayRange));
     } else {
-      const text = formatEventListText(filtered, dayRange);
-      deps.write(text || "No events found.");
+      const text = formatEventListText(filtered, dayRange) || "No events found.";
+      const note = formatFailedCalendarsNote(failedCalendars);
+      deps.write(note ? `${text}\n\n${note}` : text);
     }
   }
 

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -507,7 +507,8 @@ describe("search command", () => {
       expect(errOutput.join("\n")).not.toContain("hidden by --busy");
     });
 
-    // handleSearch silences stderr entirely in quiet mode.
+    // handleSearch silences stderr in quiet mode, apart from the warning about
+    // a calendar that failed to fetch; nothing fails in this scenario.
     it("does not warn in --quiet mode", async () => {
       const { errOutput } = await runSearch(makeMockApi([conference]), {
         query: "学会",
@@ -713,15 +714,22 @@ describe("search partial calendar failures", () => {
     expect(json.data.failed_calendars).toEqual([]);
   });
 
+  // Distinguishable errors on purpose: with the same error on both calendars,
+  // rethrowing the last failure instead of the first would still pass.
   it("throws the first error when every calendar fails", async () => {
+    const notFound = new Error("Calendar not found") as Error & { code: number };
+    notFound.code = 404;
     const api = makeFailingApi({
       primary: makeRateLimitError(),
-      "work@group.calendar.google.com": makeRateLimitError(),
+      "work@group.calendar.google.com": notFound,
     });
 
-    await expect(runSearch(api, { query: "meeting", format: "json", calendars })).rejects.toThrow(
-      "Rate Limit Exceeded",
-    );
+    await expect(
+      runSearch(api, { query: "meeting", format: "json", calendars }),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      message: expect.stringContaining("Rate Limit Exceeded"),
+    });
   });
 
   // The most common setup: one enabled calendar, so "all failed" is "it failed".

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -662,3 +662,108 @@ describe("search command", () => {
     });
   });
 });
+
+describe("search partial calendar failures", () => {
+  const calendars = [
+    { id: "primary", name: "Main Calendar", enabled: true },
+    { id: "work@group.calendar.google.com", name: "Work", enabled: true },
+  ];
+
+  function makeRateLimitError(): Error {
+    const error = new Error("Rate Limit Exceeded") as Error & { code: number };
+    error.code = 429;
+    return error;
+  }
+
+  /** A mock API that rejects for the calendar ids listed in `failures`. */
+  function makeFailingApi(failures: Record<string, Error>): GoogleCalendarApi {
+    const api = makeMockApi([makeEvent({ id: "e1" })]);
+    const succeed = api.events.list;
+    api.events.list = vi.fn().mockImplementation(async (params: { calendarId: string }) => {
+      const error = failures[params.calendarId];
+      if (error) throw error;
+      return succeed(params);
+    });
+    return api;
+  }
+
+  it("returns the events it could fetch and lists the failed calendar", async () => {
+    const api = makeFailingApi({ "work@group.calendar.google.com": makeRateLimitError() });
+
+    const result = await runSearch(api, { query: "meeting", format: "json", calendars });
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.output.join(""));
+    expect(json.data.count).toBe(1);
+    expect(json.data.failed_calendars).toEqual([
+      {
+        id: "work@group.calendar.google.com",
+        name: "Work",
+        error: { code: "RATE_LIMITED", message: expect.stringContaining("Rate Limit Exceeded") },
+      },
+    ]);
+  });
+
+  it("returns an empty failed_calendars array when every calendar succeeds", async () => {
+    const api = makeFailingApi({});
+
+    const result = await runSearch(api, { query: "meeting", format: "json", calendars });
+
+    const json = JSON.parse(result.output.join(""));
+    expect(json.data.failed_calendars).toEqual([]);
+  });
+
+  it("throws the first error when every calendar fails", async () => {
+    const api = makeFailingApi({
+      primary: makeRateLimitError(),
+      "work@group.calendar.google.com": makeRateLimitError(),
+    });
+
+    await expect(runSearch(api, { query: "meeting", format: "json", calendars })).rejects.toThrow(
+      "Rate Limit Exceeded",
+    );
+  });
+
+  // The most common setup: one enabled calendar, so "all failed" is "it failed".
+  it("throws when the only configured calendar fails", async () => {
+    const api = makeFailingApi({ primary: makeRateLimitError() });
+
+    await expect(
+      runSearch(api, {
+        query: "meeting",
+        format: "json",
+        calendars: [{ id: "primary", name: "Main Calendar", enabled: true }],
+      }),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED" });
+  });
+
+  it("warns on stderr about the failed calendar", async () => {
+    const api = makeFailingApi({ "work@group.calendar.google.com": makeRateLimitError() });
+
+    const result = await runSearch(api, { query: "meeting", format: "json", calendars });
+
+    expect(result.errOutput.join("\n")).toContain('failed to fetch calendar "Work"');
+  });
+
+  // A failure notice is not data, so --quiet does not hide it (as in list).
+  it("keeps the stderr warning under --quiet", async () => {
+    const api = makeFailingApi({ "work@group.calendar.google.com": makeRateLimitError() });
+
+    const result = await runSearch(api, { query: "meeting", quiet: true, calendars });
+
+    expect(result.errOutput.join("\n")).toContain('failed to fetch calendar "Work"');
+    expect(result.errOutput.join("\n")).not.toContain("Searching:");
+  });
+
+  it("notes the failure at the end of the text output but not under --quiet", async () => {
+    const api = makeFailingApi({ "work@group.calendar.google.com": makeRateLimitError() });
+
+    const text = await runSearch(api, { query: "meeting", calendars });
+    expect(text.output.join("\n")).toContain(
+      "Note: 1 calendar could not be fetched (see warnings above).",
+    );
+
+    const quiet = await runSearch(api, { query: "meeting", quiet: true, calendars });
+    expect(quiet.output.join("\n")).not.toContain("could not be fetched");
+  });
+});

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -4,11 +4,13 @@ import { listEvents } from "../lib/api.ts";
 import { applyFilters, findHiddenAllDayEvents } from "../lib/filter.ts";
 import type { FilterOptions, TransparencyOption } from "../lib/filter.ts";
 import {
+  formatFailedCalendarsNote,
   formatHiddenAllDayWarning,
   formatJsonSuccess,
   formatSearchResultText,
   formatQuietText,
 } from "../lib/output.ts";
+import { fetchFromCalendars } from "../lib/multi-calendar.ts";
 import { collect } from "./shared.ts";
 import { formatDateTimeInZone, parseDateTimeInZone } from "../lib/timezone.ts";
 import { addDays } from "date-fns";
@@ -42,6 +44,9 @@ interface CommandResult {
 export async function handleSearch(opts: SearchHandlerOptions): Promise<CommandResult> {
   const { api, query, format, calendars, timezone, write, quiet } = opts;
   const writeErr = quiet ? () => {} : (opts.writeErr ?? (() => {}));
+  // A failed calendar is a failure notice rather than data, so it survives
+  // --quiet -- the same as in `list`.
+  const warn = opts.writeErr ?? (() => {});
 
   const now = new Date();
   const days = opts.days ?? DEFAULT_SEARCH_DAYS;
@@ -86,10 +91,11 @@ export async function handleSearch(opts: SearchHandlerOptions): Promise<CommandR
     writeErr("Tip: Use --days <n> or --from/--to to change the search range.");
   }
 
-  const results = await Promise.all(
-    calendars.map((cal) => listEvents(api, cal.id, cal.name, { timeMin, timeMax, q: query })),
+  const { events: allEvents, failedCalendars } = await fetchFromCalendars(
+    calendars,
+    (cal) => listEvents(api, cal.id, cal.name, { timeMin, timeMax, q: query }),
+    warn,
   );
-  const allEvents = results.flat();
 
   const transparency: TransparencyOption = opts.busy ? "busy" : opts.free ? "free" : undefined;
   const filterOpts: FilterOptions = { transparency };
@@ -109,12 +115,15 @@ export async function handleSearch(opts: SearchHandlerOptions): Promise<CommandR
         query,
         events: filtered,
         count: filtered.length,
+        failed_calendars: failedCalendars,
       }),
     );
   } else if (quiet) {
     write(formatQuietText(filtered));
   } else {
-    write(formatSearchResultText(query, filtered));
+    const text = formatSearchResultText(query, filtered);
+    const note = formatFailedCalendarsNote(failedCalendars);
+    write(note ? `${text}\n\n${note}` : text);
   }
 
   return { exitCode: ExitCode.SUCCESS };

--- a/src/lib/multi-calendar.test.ts
+++ b/src/lib/multi-calendar.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CalendarConfig, CalendarEvent } from "../types/index.ts";
+import { ApiError } from "./api.ts";
+import { fetchFromCalendars } from "./multi-calendar.ts";
+
+function makeEvent(id: string, calendar: CalendarConfig): CalendarEvent {
+  return {
+    id,
+    title: `Event ${id}`,
+    description: null,
+    start: "2026-02-23T10:00:00+09:00",
+    end: "2026-02-23T11:00:00+09:00",
+    all_day: false,
+    calendar_id: calendar.id,
+    calendar_name: calendar.name,
+    html_link: `https://calendar.google.com/event/${id}`,
+    status: "confirmed",
+    transparency: "opaque",
+    attendees: [],
+    meet_link: null,
+    conference: null,
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+  };
+}
+
+const main: CalendarConfig = { id: "primary", name: "Main Calendar", enabled: true };
+const work: CalendarConfig = { id: "work@group.calendar.google.com", name: "Work", enabled: true };
+
+describe("fetchFromCalendars", () => {
+  it("collects events from every calendar and reports no failures", async () => {
+    const writeErr = vi.fn();
+
+    const result = await fetchFromCalendars(
+      [main, work],
+      async (cal) => [makeEvent(cal.id, cal)],
+      writeErr,
+    );
+
+    expect(result.events.map((e) => e.id)).toEqual(["primary", "work@group.calendar.google.com"]);
+    expect(result.failedCalendars).toEqual([]);
+    expect(writeErr).not.toHaveBeenCalled();
+  });
+
+  it("keeps the events it could fetch and describes the failed calendar", async () => {
+    const writeErr = vi.fn();
+
+    const result = await fetchFromCalendars(
+      [main, work],
+      async (cal) => {
+        if (cal.id === work.id) throw new ApiError("RATE_LIMITED", "Rate Limit Exceeded");
+        return [makeEvent(cal.id, cal)];
+      },
+      writeErr,
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.failedCalendars).toEqual([
+      {
+        id: work.id,
+        name: "Work",
+        error: { code: "RATE_LIMITED", message: "Rate Limit Exceeded" },
+      },
+    ]);
+    expect(writeErr).toHaveBeenCalledWith(
+      expect.stringContaining('failed to fetch calendar "Work"'),
+    );
+  });
+
+  it("codes a non-ApiError failure as API_ERROR", async () => {
+    const result = await fetchFromCalendars(
+      [main, work],
+      async (cal) => {
+        if (cal.id === work.id) throw new Error("socket hang up");
+        return [makeEvent(cal.id, cal)];
+      },
+      () => {},
+    );
+
+    expect(result.failedCalendars[0]!.error).toEqual({
+      code: "API_ERROR",
+      message: "socket hang up",
+    });
+  });
+
+  it("rethrows the first error when every calendar fails", async () => {
+    const first = new ApiError("RATE_LIMITED", "Rate Limit Exceeded");
+
+    await expect(
+      fetchFromCalendars(
+        [main, work],
+        async (cal) => {
+          throw cal.id === main.id ? first : new ApiError("FORBIDDEN", "Insufficient permission");
+        },
+        () => {},
+      ),
+    ).rejects.toBe(first);
+  });
+
+  it("returns an empty result for an empty calendar list", async () => {
+    const fetch = vi.fn();
+
+    const result = await fetchFromCalendars([], fetch, () => {});
+
+    expect(result).toEqual({ events: [], failedCalendars: [] });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/multi-calendar.ts
+++ b/src/lib/multi-calendar.ts
@@ -32,19 +32,24 @@ export async function fetchFromCalendars(
 
   const events: CalendarEvent[] = [];
   const failedCalendars: FailedCalendar[] = [];
+  let firstReason: unknown;
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]!;
     const calendar = calendars[i]!;
     if (result.status === "fulfilled") {
       events.push(...result.value);
     } else {
+      if (failedCalendars.length === 0) firstReason = result.reason;
+      // Warn per calendar even when the rethrow below repeats one of these:
+      // three calendars failing for three reasons are only all visible here,
+      // since the thrown error names just one of them. Deliberate duplication.
       writeErr(`Warning: failed to fetch calendar "${calendar.name}": ${result.reason}`);
       failedCalendars.push(toFailedCalendar(calendar, result.reason));
     }
   }
 
   if (calendars.length > 0 && failedCalendars.length === calendars.length) {
-    throw (settled[0] as PromiseRejectedResult).reason;
+    throw firstReason;
   }
 
   return { events, failedCalendars };

--- a/src/lib/multi-calendar.ts
+++ b/src/lib/multi-calendar.ts
@@ -1,0 +1,51 @@
+import type { CalendarConfig, CalendarEvent, ErrorCode, FailedCalendar } from "../types/index.ts";
+import { ApiError } from "./api.ts";
+
+export interface MultiCalendarResult {
+  events: CalendarEvent[];
+  failedCalendars: FailedCalendar[];
+}
+
+function toFailedCalendar(calendar: CalendarConfig, reason: unknown): FailedCalendar {
+  const code: ErrorCode = reason instanceof ApiError ? reason.code : "API_ERROR";
+  const message = reason instanceof Error ? reason.message : String(reason);
+  return { id: calendar.id, name: calendar.name, error: { code, message } };
+}
+
+/**
+ * Fetch from every calendar at once, keeping what came back and describing what
+ * did not. A calendar that fails is warned about on stderr and listed in
+ * `failedCalendars`, so a JSON reader sees the failure without parsing stderr.
+ *
+ * When *every* calendar fails the first error is rethrown instead: an empty
+ * result would claim the calendars are empty, and with the usual single-calendar
+ * setup "all failed" is simply "the fetch failed".
+ *
+ * Shared by `list` and `search` so the two cannot drift apart.
+ */
+export async function fetchFromCalendars(
+  calendars: CalendarConfig[],
+  fetch: (calendar: CalendarConfig) => Promise<CalendarEvent[]>,
+  writeErr: (msg: string) => void,
+): Promise<MultiCalendarResult> {
+  const settled = await Promise.allSettled(calendars.map((cal) => fetch(cal)));
+
+  const events: CalendarEvent[] = [];
+  const failedCalendars: FailedCalendar[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]!;
+    const calendar = calendars[i]!;
+    if (result.status === "fulfilled") {
+      events.push(...result.value);
+    } else {
+      writeErr(`Warning: failed to fetch calendar "${calendar.name}": ${result.reason}`);
+      failedCalendars.push(toFailedCalendar(calendar, result.reason));
+    }
+  }
+
+  if (calendars.length > 0 && failedCalendars.length === calendars.length) {
+    throw (settled[0] as PromiseRejectedResult).reason;
+  }
+
+  return { events, failedCalendars };
+}

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Calendar, CalendarEvent } from "../types/index.ts";
+import type { Calendar, CalendarEvent, FailedCalendar } from "../types/index.ts";
 import {
   formatJsonSuccess,
   formatJsonError,
@@ -9,6 +9,7 @@ import {
   formatEventDetailText,
   formatQuietText,
   formatHiddenAllDayWarning,
+  formatFailedCalendarsNote,
   errorCodeToExitCode,
 } from "./output.ts";
 
@@ -888,5 +889,31 @@ describe("formatHiddenAllDayWarning", () => {
 
   it("returns an empty string when nothing is hidden", () => {
     expect(formatHiddenAllDayWarning([])).toBe("");
+  });
+});
+
+describe("formatFailedCalendarsNote", () => {
+  function failed(name: string): FailedCalendar {
+    return {
+      id: `${name}@group.calendar.google.com`,
+      name,
+      error: { code: "RATE_LIMITED", message: "Rate Limit Exceeded" },
+    };
+  }
+
+  it("names the count of calendars that could not be fetched", () => {
+    expect(formatFailedCalendarsNote([failed("Work")])).toBe(
+      "Note: 1 calendar could not be fetched (see warnings above).",
+    );
+  });
+
+  it("pluralises for several calendars", () => {
+    expect(formatFailedCalendarsNote([failed("Work"), failed("Family")])).toBe(
+      "Note: 2 calendars could not be fetched (see warnings above).",
+    );
+  });
+
+  it("returns an empty string when nothing failed", () => {
+    expect(formatFailedCalendarsNote([])).toBe("");
   });
 });

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,4 +1,4 @@
-import type { Calendar, CalendarEvent, ErrorCode } from "../types/index.ts";
+import type { Calendar, CalendarEvent, ErrorCode, FailedCalendar } from "../types/index.ts";
 import { ExitCode } from "../types/index.ts";
 import { expandEventsByDay, type DayRange, type EventDay } from "./event-days.ts";
 
@@ -148,6 +148,17 @@ export function formatHiddenAllDayWarning(events: CalendarEvent[]): string {
   if (remaining > 0) lines.push(`  ... and ${remaining} more`);
 
   return lines.join("\n");
+}
+
+/**
+ * One line for the end of the text output. The details are already on stderr;
+ * this only tells a stdout reader that the listing is incomplete.
+ */
+export function formatFailedCalendarsNote(failed: FailedCalendar[]): string {
+  if (failed.length === 0) return "";
+
+  const noun = failed.length === 1 ? "calendar" : "calendars";
+  return `Note: ${failed.length} ${noun} could not be fetched (see warnings above).`;
 }
 
 interface QuietRow {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,20 @@ export type ErrorCode =
   | "RATE_LIMITED"
   | "CONFIG_ERROR";
 
+/**
+ * A calendar whose fetch failed while at least one other succeeded. `list` and
+ * `search` always report the array -- empty when nothing failed -- so an agent
+ * never has to test for the key.
+ */
+export interface FailedCalendar {
+  id: string;
+  name: string;
+  error: {
+    code: ErrorCode;
+    message: string;
+  };
+}
+
 export interface SuccessResponse<T> {
   success: true;
   data: T;

--- a/tests/integration/error-propagation.test.ts
+++ b/tests/integration/error-propagation.test.ts
@@ -34,7 +34,7 @@ describe("error propagation: API errors → command handler → output", () => {
       return err;
     }
 
-    it("list: auth error is caught per-calendar and reported via writeErr", async () => {
+    it("list: auth error on the only calendar propagates instead of an empty success", async () => {
       const mockApi = createMockApi({
         errors: { listEvents: makeAuthError() },
       });
@@ -50,13 +50,12 @@ describe("error propagation: API errors → command handler → output", () => {
         now: () => new Date("2026-02-23T10:00:00+09:00"),
       };
 
-      const result = await handleList({ today: true, format: "json", quiet: false }, deps);
-
-      // List uses Promise.allSettled, so auth errors are reported per-calendar
-      expect(result.exitCode).toBe(0);
+      // Every calendar failed, so there is nothing to report as a success.
+      await expect(handleList({ today: true, format: "json", quiet: false }, deps)).rejects.toThrow(
+        "Request had invalid authentication credentials",
+      );
       expect(writeErr).toHaveBeenCalled();
-      const json = JSON.parse(out.output());
-      expect(json.data.events).toEqual([]);
+      expect(out.output()).toBe("");
     });
 
     it("search: auth error propagates from API", async () => {

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -12,6 +12,8 @@ export interface MockApiData {
   deletedEvents?: { calendarId: string; eventId: string }[];
   errors?: {
     listEvents?: Error;
+    /** Fails only the listed calendar ids, leaving the others to succeed. */
+    listEventsByCalendar?: Record<string, Error>;
     getEvent?: Error;
     insertEvent?: Error;
     patchEvent?: Error;
@@ -33,6 +35,8 @@ export function createMockApi(data: MockApiData = {}): GoogleCalendarApi {
     events: {
       list: vi.fn().mockImplementation(async (params: { calendarId: string }) => {
         if (data.errors?.listEvents) throw data.errors.listEvents;
+        const perCalendar = data.errors?.listEventsByCalendar?.[params.calendarId];
+        if (perCalendar) throw perCalendar;
         const events = data.events?.[params.calendarId] ?? [];
         return { data: { items: events } };
       }),

--- a/tests/integration/list-pipeline.test.ts
+++ b/tests/integration/list-pipeline.test.ts
@@ -304,4 +304,41 @@ describe("list command pipeline: config → API → filter → output", () => {
     const json = JSON.parse(out.output());
     expect(json.data.count).toBe(2);
   });
+
+  it("reports a calendar the API rejected while keeping the events it got", async () => {
+    const rateLimited = new Error("Rate Limit Exceeded") as Error & { code: number };
+    rateLimited.code = 429;
+    const mockApi = createMockApi({
+      events: { primary: [makeGoogleEvent({ id: "e1", summary: "Morning Standup" })] },
+      errors: { listEventsByCalendar: { "work@group.calendar.google.com": rateLimited } },
+    });
+    const mockFs = createMockFs(SAMPLE_CONFIG_TOML);
+    const out = captureWrite();
+    const writeErr = vi.fn();
+
+    const deps: ListHandlerDeps = {
+      listEvents: (calId, calName, opts) => listEvents(mockApi, calId, calName, opts),
+      loadConfig: () => loadConfig(mockFs),
+      write: out.write,
+      writeErr,
+      now: NOW,
+    };
+
+    const result = await handleList({ today: true, format: "json", quiet: false }, deps);
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(out.output());
+    expect(json.data.count).toBe(1);
+    expect(json.data.events[0].title).toBe("Morning Standup");
+    expect(json.data.failed_calendars).toEqual([
+      {
+        id: "work@group.calendar.google.com",
+        name: "Work",
+        error: { code: "RATE_LIMITED", message: expect.stringContaining("Rate Limit Exceeded") },
+      },
+    ]);
+    expect(writeErr).toHaveBeenCalledWith(
+      expect.stringContaining('failed to fetch calendar "Work"'),
+    );
+  });
 });

--- a/tests/integration/search-pipeline.test.ts
+++ b/tests/integration/search-pipeline.test.ts
@@ -175,4 +175,42 @@ describe("search command pipeline: config → API → filter → output", () => 
     expect(searchingLine).toContain("2026-03-31");
     expect(searchingLine).not.toContain("2026-04-01");
   });
+
+  it("reports a calendar the API rejected while keeping the events it got", async () => {
+    const rateLimited = new Error("Rate Limit Exceeded") as Error & { code: number };
+    rateLimited.code = 429;
+    const mockApi = createMockApi({
+      events: { primary: [makeGoogleEvent({ id: "e1", summary: "Team Meeting" })] },
+      errors: { listEventsByCalendar: { "work@group.calendar.google.com": rateLimited } },
+    });
+    const mockFs = createMockFs(SAMPLE_CONFIG_TOML);
+
+    const config = loadConfig(mockFs);
+    const out = captureWrite();
+    const writeErr = vi.fn();
+
+    const result = await handleSearch({
+      api: mockApi,
+      query: "Meeting",
+      format: "json",
+      calendars: selectCalendars(undefined, config),
+      timezone: resolveTimezone(undefined, config.timezone),
+      write: out.write,
+      writeErr,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(out.output());
+    expect(json.data.count).toBe(1);
+    expect(json.data.failed_calendars).toEqual([
+      {
+        id: "work@group.calendar.google.com",
+        name: "Work",
+        error: { code: "RATE_LIMITED", message: expect.stringContaining("Rate Limit Exceeded") },
+      },
+    ]);
+    expect(writeErr).toHaveBeenCalledWith(
+      expect.stringContaining('failed to fetch calendar "Work"'),
+    );
+  });
 });


### PR DESCRIPTION
Implements `spec/tasks/047-partial-failure-reporting.md`.

## Problem

`gcal list` folded a failed calendar fetch into a stderr warning and still returned `success: true`, `count: 0`, exit 0 — an agent parsing stdout could not tell a rate-limited or unauthorized fetch from an empty calendar. `gcal search` did the opposite: `Promise.all` meant one failing calendar threw away every other calendar's results.

## What changed

- New `FailedCalendar` type (`{ id, name, error: { code, message } }`). `error.code` is the `ApiError`'s `ErrorCode`, or `API_ERROR` when the failure carries no code.
- New `src/lib/multi-calendar.ts` with `fetchFromCalendars()`, shared by both commands so they cannot drift apart. It keeps what came back, warns on stderr per failed calendar exactly as before, lists the failures, and rethrows the first error when *every* calendar fails.
- `list` and `search` JSON output gain `data.failed_calendars`, **always present**, `[]` when nothing failed (the `attendees: []` precedent from 041).
- `search` moves from `Promise.all` to the shared helper, so its four cases (partial failure / no failure / all failed / single calendar failed) now match `list` exactly.
- Text output gains one line after the listing when something failed: `Note: 1 calendar could not be fetched (see warnings above).` Omitted under `--quiet`.
- `spec/output.md` and `spec/commands.md` updated.

## Behavior changes reviewers should note

1. **JSON shape**: `gcal list -f json` and `gcal search -f json` now always include `data.failed_calendars`. Any consumer doing an exact-shape comparison of `data` will see the new key (one existing unit test asserted the exact envelope and was updated).
2. **Exit code**: when *every* calendar fails, both commands now raise the first error instead of printing an empty success. `list` previously exited 0 here; it now exits according to `error.code` (e.g. 2 for `AUTH_REQUIRED`, 1 for `RATE_LIMITED`). This is the most consequential change, because with the common single-calendar config "all failed" is simply "the fetch failed" — exactly the case that used to return a silent success. `tests/integration/error-propagation.test.ts` asserted the old silent-success behavior and was rewritten.
3. **`--quiet` in `search`**: the task left this open. `list` printed its warnings even under `--quiet`; `search` suppressed all stderr. I aligned `search` to `list`, but only for the failed-calendar warning: a failure notice is not data, and dropping it would leave `-q` users with no signal at all (the text `Note:` line is also suppressed under `-q`). `search`'s other stderr messages (`Searching:`, the `--days` tip, the `--busy` all-day notice) stay suppressed under `--quiet`, as documented. So `gcal search -q` can now emit one stderr line it previously did not.

## Testing

`bun run --bun vitest run src tests/integration` — 998 tests, 41 files, all passing. `typecheck`, `lint`, `format:check` clean.

New coverage: 5 unit tests for `fetchFromCalendars`, 8 for `handleList`, 7 for `handleSearch` (all four cases in both commands, including a dedicated single-calendar test), 3 for the text note formatter, and one end-to-end API-error → `failed_calendars` test in each of the list and search pipelines (the mock API gained a per-calendar `listEventsByCalendar` error map).

## Not verified

No e2e test, as the task specifies: a single calendar cannot be made to fail reliably against the real API. Nothing here was exercised against live Google Calendar — the mapping from a real 403/429 to `ErrorCode` is the pre-existing `mapApiError()` path, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YB6iUb89Fr1HYsQucbgoo